### PR TITLE
fix: #158 flash glitch

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -8,6 +8,3 @@ module.exports = (on, config) => {
 
         return config
 }
-~                                                                                                                
-~                                                                                                                
-~              

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { ServerStyleSheets } from '@material-ui/core/styles';
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head>
+          
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+MyDocument.getInitialProps = async (ctx) => {
+  const sheets = new ServerStyleSheets();
+  const originalRenderPage = ctx.renderPage;
+
+  ctx.renderPage = () =>
+    originalRenderPage({
+      enhanceApp: (App) => (props) => sheets.collect(<App {...props} />),
+    });
+
+  const initialProps = await Document.getInitialProps(ctx);
+
+  return {
+    ...initialProps,
+    styles: [...React.Children.toArray(initialProps.styles), sheets.getStyleElement()],
+  };
+};

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import Home from '../Home';
+import Home from '../components/Home';
 
 
 export default function Homepage() {


### PR DESCRIPTION
The problem was that material ui uses jss for styling so the styles were being loaded post javascript loaded. We just needed to add a custom document and inject the styles there so they can be rendered server side. 