### PR TITLE
feat: badge component #154

### DIFF
--- a/src/components/VerifiedBadge.cy.js
+++ b/src/components/VerifiedBadge.cy.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { mount } from '@cypress/react';
+import VerifiedBadge from './VerifiedBadge';
+
+describe('Verified Badge', () => {
+  it('enabled', () => {
+    mount(<VerifiedBadge verified={true} badgeName="Tree Verified" />);
+  });
+  it('not enabled', () => {
+    mount(<VerifiedBadge verified={false} badgeName="Tree Verified" />);
+  });
+});

--- a/src/components/VerifiedBadge.js
+++ b/src/components/VerifiedBadge.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import CheckIcon from '@material-ui/icons/Check';
+import { Chip } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(() => ({
+  chip: {
+    borderRadius: '4px',
+  },
+}));
+
+function VerifiedBadge({ verified, badgeName }) {
+  const classes = useStyles();
+  return (
+    <Chip
+      className={classes.chip}
+      color={!verified ? 'primary' : 'secondary'}
+      size="small"
+      icon={<CheckIcon />}
+      label={badgeName}
+      disabled={!verified}
+    />
+  );
+}
+
+export default VerifiedBadge;


### PR DESCRIPTION
![Tree Verified](https://user-images.githubusercontent.com/80873472/135412555-29b0bcd5-80a3-4d46-bfde-cc838951bde1.PNG)

Added Badge component. The reason the photo is the wrong color is because The ThemeProvider isn't mounted by Cypress, Some of the other component tests that were dependent on the theme had the same issues so we probably need to raise this as an issue. If you put the component in the applciaion it will be green when enabled and low opacity white/grey when disabled.

 