### PR TITLE
refactor: switched date format from MM/DD to DD/MM

### DIFF
--- a/src/components/SidePanel.js
+++ b/src/components/SidePanel.js
@@ -466,7 +466,7 @@ function SidePanel(props){
             {treeDetail &&
               <>
                 <List icon={AccessTime} tooltip="Create date" >
-                  <Item title="Created at" value={new Date(treeDetail.time_created).toLocaleString("en-US")} />
+                  <Item title="Created at" value={new Date(treeDetail.time_created).toLocaleString("en-GB")} />
                 </List>
                 <List
                   icon={Face}

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -122,7 +122,7 @@ const marks = ['2015',  '2017',  '2019',  '2021'].map(e => {
 });
 
 function valuetext(value) {
-  return moment('2015-01-01').add(value, "days").format("YYYY-MM-DD");
+  return moment('2015-01-01').add(value, "days").format("DD-MM-YYYY");
 }
 
 function textvalue(begin, end){


### PR DESCRIPTION
Resolves #177  Changes the dates on the website from the American format to European format. The pictures below show the change. Refactored in the side component of a specific tree, as well as the date slider.


<img width="513" alt="Anonymoust P" src="https://user-images.githubusercontent.com/36649892/137016884-fb7bec45-723a-4795-a5c8-e7eed1ed9099.png">
.
<img width="472" alt="27-03-2017" src="https://user-images.githubusercontent.com/36649892/137016938-f2f794db-8b07-4a11-a131-95ed496dd35f.png">

