### PR TITLE
fix: cypress-ct font loading

### DIFF
--- a/cypress/support/components-testing.js
+++ b/cypress/support/components-testing.js
@@ -16,3 +16,11 @@
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 import './commands';
+
+import WebFont from 'webfontloader';
+
+WebFont.load({
+  google: {
+    families: ['Lato', 'Montserrat'],
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
 				"lint-staged": "^11.2.3",
 				"nock": "^13.1.3",
 				"prettier": "^2.4.1",
+				"webfontloader": "^1.6.28",
 				"webpack": "^5.58.2",
 				"webpack-dev-server": "^3.11.2"
 			},
@@ -20790,6 +20791,12 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
+		"node_modules/webfontloader": {
+			"version": "1.6.28",
+			"resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
+			"integrity": "sha1-23hhKSU8tujq5UwvsF+HCvZnW64=",
+			"dev": true
+		},
 		"node_modules/webidl-conversions": {
 			"version": "4.0.2",
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
@@ -36902,6 +36909,12 @@
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
 			}
+		},
+		"webfontloader": {
+			"version": "1.6.28",
+			"resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
+			"integrity": "sha1-23hhKSU8tujq5UwvsF+HCvZnW64=",
+			"dev": true
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"dev:mock": "concurrently \"npm run mock-server\" \"npm run dev\"",
 		"cy": "cypress open",
 		"cyu": "cypress open-ct",
+		"cyux": "rm -rf .next/; npm run cyu",
 		"cypress:open": "cypress open",
 		"cypress:run": "cypress run",
 		"eject": "react-scripts eject",
@@ -90,6 +91,7 @@
 		"lint-staged": "^11.2.3",
 		"nock": "^13.1.3",
 		"prettier": "^2.4.1",
+		"webfontloader": "^1.6.28",
 		"webpack": "^5.58.2",
 		"webpack-dev-server": "^3.11.2"
 	},


### PR DESCRIPTION
resolves #230 

I resolved this by adding webfontloader as a dev package and using the cypress support file to run it before each test.

I also added `"cyux": "rm -rf .next/; npm run cyu",` as a helper script until #229 is resolved