### PR TITLE
fix: auto-refreshing the page in dev mode #255

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -365,6 +365,7 @@ function MapComponent() {
 
   // load map
   React.useEffect(() => {
+    if (mapContext.map) return;
     log.info('load map...');
     // disable waiting for loading
     loaded();


### PR DESCRIPTION
Fix the bug, by testing if the  MapContext has already updated the map object.
I think it's can be fixed in a better way, by moving the creation of the Map object inside MapContextProvider, and providing for the consumer's context just a init function instead of setMap, but NextJS don't allow the import of the class Map. 