### PR TITLE
Hotfix/lint staged

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,3 @@ dist/
 coverage/
 node_modules/
 package-lock.json
-*.css

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install lint-staged
+npm run lint:errors

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,6 @@
 module.exports = {
-  '*.{js,jsx,ts,tsx,html,css}': ['prettier --write', 'eslint --fix'],
-  '*.{md,json,yml,yaml}': ['prettier --write'],
+  // format all file types recognized by prettier
+  '*': ['prettier --ignore-unknown --write'],
+  // lint javascript after formatting
+  '*.{js,jsx}': ['eslint --fix --cache'],
 };

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "eject": "react-scripts eject",
-    "eslint:only-errors": "eslint --quiet .",
     "lint": "eslint .",
-    "lint:fix": "prettier . --write; eslint . --fix",
+    "lint:fix": "eslint . --fix --cache",
+    "lint:errors": "eslint . --quiet --cache",
     "prettier": "prettier ./ --write",
+    "format": "npm run prettier; npm run lint:fix",
     "mock-server": "prism mock ./doc/web-map-api.yaml",
     "test": "jest --watch",
     "prepare": "is-ci || husky install"


### PR DESCRIPTION
resolves #270 

This was a mistake in the lint-staged config file, css files should not have been sent to eslint. 

I recognize your concern with changes to the eslint rules introducing unchecked linting errors. By taking advantage of eslint's cache feature I added fast error checking of the entire project to the pre commit hook. This will happen after the lint-staged script has a chance to fix the eslint errors and prevent an unsuccessful commit. The docs do not mention this but any changes to the eslint config will reset the cache so that the whole project is scanned.

https://eslint.org/docs/user-guide/command-line-interface#--cache