### PR TITLE
fix: #253 on initial page load clicking on link rerenders page

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -25,23 +25,3 @@ export default class MyDocument extends Document {
     );
   }
 }
-
-MyDocument.getInitialProps = async (ctx) => {
-  const sheets = new ServerStyleSheets();
-  const originalRenderPage = ctx.renderPage;
-
-  ctx.renderPage = () =>
-    originalRenderPage({
-      enhanceApp: (App) => (props) => sheets.collect(<App {...props} />),
-    });
-
-  const initialProps = await Document.getInitialProps(ctx);
-
-  return {
-    ...initialProps,
-    styles: [
-      ...React.Children.toArray(initialProps.styles),
-      sheets.getStyleElement(),
-    ],
-  };
-};


### PR DESCRIPTION
The issue is related to getInitialProps. From next.js doc:

"For the initial page load, getInitialProps will run on the server only. getInitialProps will then run on the client when navigating to a different route via the next/link component or by using next/router. However, if getInitialProps is used in a custom _app.js, and the page being navigated to implements getServerSideProps, then getInitialProps will run on the server."  (https://nextjs.org/docs/api-reference/data-fetching/getInitialProps)

 This is the log from what I saw:
<img width="864" alt="Screen Shot 2021-11-09 at 11 04 43 AM" src="https://user-images.githubusercontent.com/35870835/140970759-16dc7658-bfbb-41b9-9c6a-9c59a67ef418.png">

Not sure if this is ideal fix... But this is the problem I saw.  
