### PR TITLE
fix: add test to requestAPI, and modify requestAPI to use axios … #275

### DIFF
--- a/src/models/utils.js
+++ b/src/models/utils.js
@@ -1,4 +1,5 @@
 import { catchClause } from '@babel/types';
+import axios from 'axios';
 
 const log = require('loglevel');
 
@@ -49,15 +50,12 @@ function parseMapName(domain) {
 async function requestAPI(url) {
   try {
     let urlFull = `${process.env.NEXT_PUBLIC_API_NEW}${url}`;
-    // TODO remove test code
     urlFull = urlFull.replace(/\?/, '/query/');
-    log.warn('url:', urlFull);
-    const res = await fetch(urlFull);
-    const result = await res.json();
-    return result;
-  } catch (error) {
-    log.error(error);
-    throw error;
+
+    const res = await axios(urlFull);
+    return res.data;
+  } catch (ex) {
+    throw new Error(ex.message);
   }
 }
 

--- a/src/models/utils.test.js
+++ b/src/models/utils.test.js
@@ -1,4 +1,4 @@
-import { parseDomain, parseMapName } from './utils';
+import { parseDomain, parseMapName, requestAPI } from './utils';
 
 describe('parseMapName', () => {
   it('freetown.treetracker.org should return freetown', () => {
@@ -76,5 +76,15 @@ describe('parseDomain', () => {
     expect(parseDomain('https://treetracker.org/?wallet=xxxx')).toBe(
       'treetracker.org',
     );
+  });
+});
+
+describe('requestAPI', () => {
+  it('should the request failed (code 404) with a wrong URL end point.', async () => {
+    try {
+      await requestAPI('wrong_end_point');
+    } catch (ex) {
+      expect(ex.message).toBe('Request failed with status code 404');
+    }
   });
 });


### PR DESCRIPTION
- To test this function, the use of fetch in jest/nodeJS environment will not work. fetch don't exist. instead, if we use Axios, it's throw an error when the server returns a 4XX/5XX response ( for the 404 bugs).
- for the test a just test it with a wrong URL, tell me if they are other URLs to test I will make changes for that.  