### PR TITLE
Hotfix: Map import

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -9,7 +9,7 @@ import expect from 'expect-runtime';
 import log from 'loglevel';
 import { useRouter } from 'next/router';
 import React from 'react';
-import Map from 'treetracker-web-map-core/src/Map';
+import { Map } from 'treetracker-web-map-core';
 
 import { useMapContext } from '../mapContext';
 import { parseMapName } from '../models/utils';


### PR DESCRIPTION
depends on https://github.com/Greenstand/treetracker-web-map-core/pull/27

This fixes the import to go along with changes to the web-map-core repo