### PR TITLE
fix: lint-staged settings

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,3 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npx --no-install lint-staged
-npm run lint:errors

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,6 +1,10 @@
 module.exports = {
   // format all file types recognized by prettier
   '*': ['prettier --ignore-unknown --write'],
+
   // lint javascript after formatting
-  '*.{js,jsx}': ['eslint --fix --cache'],
+  '*.{js,jsx}': ['eslint --fix --cache --quiet'],
+
+  // lint entire project if eslint settings changed
+  '.eslint*': ['eslint . --cache'],
 };


### PR DESCRIPTION
# Description

This configuration will avoid linting changed files that have not been staged. Suppose you have changed several files and want to stage and commit only one file. The current configuration will lint all changed files. This new config will only lint the staged file(s). If `.eslintrc` or `eslintignore` has been changed then the entire project will be linted to prevent rule changes from introducing new errors.

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
