### PR TITLE
fix: remove underscore style from Link component

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -48,6 +48,7 @@ function LinkComponent(props) {
       className={className}
       ref={innerRef}
       href={href}
+      sx={{ textDecoration: 'none' }}
       {...other}
     />
   );


### PR DESCRIPTION
# Description

This is some sort of issue with the custom `Link` component with the new setup. I tried copying the [latest example from mui-org](https://github.com/mui-org/material-ui/blob/master/examples/nextjs/src/Link.js) but it did not make a difference. 

Fixes #316

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules