### PR TITLE
fix: google font imports

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -11,7 +11,7 @@ class MyDocument extends Document {
         <Head>
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link
-            href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap"
             rel="stylesheet"
           />
           <link


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

I was able to locate the font error and fix #291  - Montserrat font weight 600 was not being imported, so font weight 700 was being used by default, causing the disparity in font weight compared to the figma docs.
<img width="1281" alt="Screen Shot 2021-12-01 at 10 38 51 AM" src="https://user-images.githubusercontent.com/84106309/144254255-d96782bf-49f9-4814-be75-1dc6dbd73e00.png">

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Visual confirmation (this PR is a simple four-character change to a font import so that 600 weight Montserrat is actually available in the application.)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
