### PR TITLE
fix: update informationCard CSS to match figma

### DIFF
--- a/src/components/InformationCard1.cy.js
+++ b/src/components/InformationCard1.cy.js
@@ -8,6 +8,7 @@ const info = {
   entityType: 'Planting Organisation',
   buttonText: 'Meet the Organization',
   cardImageSrc: '/src/images/greenway-international.png',
+  link: 'https://www.google.com',
 };
 
 describe('InformationCard1', () => {

--- a/src/components/InformationCard1.js
+++ b/src/components/InformationCard1.js
@@ -27,7 +27,7 @@ const useStyles = makeStyles()((theme) => ({
     fontWeight: 700,
     textTransform: 'none',
     fontSize: '1.25rem',
-    letterSpacing: '2%',
+    letterSpacing: '0.02em',
     lineHeight: theme.spacing(6),
     marginTop: theme.spacing(5),
     color: theme.palette.textPrimary.main,

--- a/src/components/InformationCard1.js
+++ b/src/components/InformationCard1.js
@@ -1,29 +1,35 @@
 import { Box, Button, CardMedia } from '@mui/material';
 import { makeStyles } from 'models/makeStyles';
 import React from 'react';
+
 import Link from './Link';
 
 const useStyles = makeStyles()((theme) => ({
   container: {
     boxSizing: 'border-box',
-    height: 220,
-    padding: '25px 30px',
+    height: 'fit-content',
+    padding: theme.spacing(6),
     background:
       'linear-gradient(120.41deg, rgba(255, 122, 0, 0.15) 25.62%, rgba(117, 185, 38, 0.4) 97.96%)',
-    borderRadius: '15px',
+    borderRadius: theme.spacing(4),
   },
   contentWrapper: {
-    gap: '9px',
-    paddingLeft: theme.spacing(2),
+    gap: theme.spacing(1),
+    paddingLeft: theme.spacing(5),
+    justifyContent: 'center',
   },
   button: {
-    height: 45,
-    borderRadius: '25px',
+    height: 52,
+    borderRadius: '26px',
     background:
       'linear-gradient(90.06deg, rgba(255, 165, 0, 0.45) 0.79%, rgba(117, 185, 38, 0.45) 49.97%, rgba(96, 137, 47, 0.6) 99.95%)',
     boxShadow: '0px 8px 16px rgba(97, 137, 47, 0.25)',
     fontWeight: 700,
     textTransform: 'none',
+    fontSize: '1.25rem',
+    letterSpacing: '2%',
+    lineHeight: theme.spacing(6),
+    marginTop: theme.spacing(5),
   },
   media: {
     height: 110,
@@ -34,11 +40,13 @@ const useStyles = makeStyles()((theme) => ({
   entityName: {
     fontFamily: theme.typography.fontFamily,
     fontWeight: 700,
-    fontSize: 18,
+    fontSize: '1.75rem',
+    color: theme.palette.textPrimary.main,
   },
   entityType: {
     fontFamily: theme.typography.fontFamily,
-    fontSize: 14,
+    fontSize: '1rem',
+    color: theme.palette.textPrimary.main,
   },
 }));
 

--- a/src/components/InformationCard1.js
+++ b/src/components/InformationCard1.js
@@ -30,6 +30,7 @@ const useStyles = makeStyles()((theme) => ({
     letterSpacing: '2%',
     lineHeight: theme.spacing(6),
     marginTop: theme.spacing(5),
+    color: theme.palette.textPrimary.main,
   },
   media: {
     height: 110,


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

# Description

Updates InformationCard CSS to more closely match figma docs, and converts hardcoded values for font color and padding/margin to theme values where possible.

Fixes #300 

<img width="777" alt="Screen Shot 2021-12-03 at 1 01 28 PM" src="https://user-images.githubusercontent.com/84106309/144642782-c05ad476-38c0-4744-94fd-8b1eb8871640.png">

## Type of change  
- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [X] Cypress integration
- [X] Cypress component tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
