### PR TITLE
feat: cypress open without nock

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,13 @@ Cypress Integration testing also includes the `cypress-watch-and-reload` plugin 
 
 API calls made inside nextJs serverless functions like `getServerSideProps()` can be mocked with the nock task we have added to cypress. The following example provides a mock response at the address being fetched during SSR.
 
+**Note**
+
+Cypress must start a custom Nextjs server to mock SSR functions. Use `cypress open --env nock=true` or `npm run cy:nock` to start cypress with a Nextjs server (this means you do not need to use `npm run dev` or `npm start`). You can use `Cypress.env('nock')` in your test files to check if the cypress nextjs server is active.
+
 ```js
 beforeEach(() => {
-  cy.task('clearNock'); // This will clear any mocks that have been set
+  Cypress.env('nock') && cy.task('clearNock'); // This will clear any mocks that have been set
 });
 
 it('getServerSideProps returns mock', () => {
@@ -231,17 +235,17 @@ it('getServerSideProps returns mock', () => {
   const testData = {
     // expected data here
   };
-
-  cy.task('nock', {
-    hostname: 'http://127.0.0.1:4010/mock',
-    method: 'GET',
-    path,
-    statusCode: 200,
-    body: {
-      ...testData,
-      status: 200,
-    },
-  });
+  Cypress.env('nock') &&
+    cy.task('nock', {
+      hostname: 'http://127.0.0.1:4010/mock',
+      method: 'GET',
+      path,
+      statusCode: 200,
+      body: {
+        ...testData,
+        status: 200,
+      },
+    });
 
   cy.visit(path);
   cy.contains(testData.someValue);

--- a/cypress.json
+++ b/cypress.json
@@ -10,5 +10,8 @@
   "component": {
     "pluginsFile": "cypress/plugins/components-testing.js",
     "supportFile": "cypress/support/components-testing.js"
+  },
+  "env": {
+    "nock": false
   }
 }

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -6,6 +6,10 @@ const next = require('next');
 // start the Next.js server when Cypress starts
 module.exports = async (on, config) => {
   require('cypress-watch-and-reload/plugins')(config);
+
+  // exit if not using nock to mock nextjs ssr functions
+  if (!config.env.nock) return config;
+
   const app = next({ dev: true });
   const handleNextRequests = app.getRequestHandler();
   await app.prepare();

--- a/cypress/tests/integration/organizations/[organizationid].cy.js
+++ b/cypress/tests/integration/organizations/[organizationid].cy.js
@@ -12,7 +12,7 @@ const organization = {
 };
 
 beforeEach(() => {
-  cy.task('clearNock');
+  Cypress.env('nock') && cy.task('clearNock');
 });
 
 describe('Organizations', () => {
@@ -22,17 +22,18 @@ describe('Organizations', () => {
     cy.fixture(imageFixturePath).then((image) => {
       const blob = Cypress.Blob.base64StringToBlob(image, 'images/png');
       const photo_url = Cypress.Blob.createObjectURL(blob);
-      cy.task('nock', {
-        hostname: 'http://127.0.0.1:4010/mock',
-        method: 'GET',
-        path,
-        statusCode: 200,
-        body: {
-          ...organization,
-          photo_url,
-          status: 200,
-        },
-      });
+      Cypress.env('nock') &&
+        cy.task('nock', {
+          hostname: 'http://127.0.0.1:4010/mock',
+          method: 'GET',
+          path,
+          statusCode: 200,
+          body: {
+            ...organization,
+            photo_url,
+            status: 200,
+          },
+        });
     });
 
     cy.visit(path, {

--- a/cypress/tests/integration/top.cy.js
+++ b/cypress/tests/integration/top.cy.js
@@ -3,35 +3,36 @@ import tree186734 from '../../fixtures/tree186734.json';
 
 describe('top', () => {
   beforeEach(() => {
-    cy.task('clearNock');
+    Cypress.env('nock') && cy.task('clearNock');
   });
 
   it('top page', () => {
-    cy.task('nocks', {
-      hostname: 'http://127.0.0.1:4010/mock',
-      routes: [
-        {
-          method: 'GET',
-          path: '/trees/featured',
-          statusCode: 200,
-          body: {
-            trees: [{ ...tree186734 }],
+    Cypress.env('nock') &&
+      cy.task('nocks', {
+        hostname: 'http://127.0.0.1:4010/mock',
+        routes: [
+          {
+            method: 'GET',
+            path: '/trees/featured',
+            statusCode: 200,
+            body: {
+              trees: [{ ...tree186734 }],
+            },
           },
-        },
-        {
-          method: 'GET',
-          path: '/trees/186734',
-          statusCode: 200,
-          body: { ...tree186734 },
-        },
-        {
-          method: 'GET',
-          path: '/countries/leader',
-          statusCode: 200,
-          body: leader,
-        },
-      ],
-    });
+          {
+            method: 'GET',
+            path: '/trees/186734',
+            statusCode: 200,
+            body: { ...tree186734 },
+          },
+          {
+            method: 'GET',
+            path: '/countries/leader',
+            statusCode: 200,
+            body: leader,
+          },
+        ],
+      });
 
     cy.visit('/top');
     cy.contains('Featured Trees');

--- a/cypress/tests/integration/trees/[treeid].cy.js
+++ b/cypress/tests/integration/trees/[treeid].cy.js
@@ -37,17 +37,18 @@ const testImage = (fileName, imageType = 'image/jpg') => {
     cy.fixture(imageFixturePath).then((image) => {
       const blob = Cypress.Blob.base64StringToBlob(image, imageType);
       const url = Cypress.Blob.createObjectURL(blob);
-      cy.task('nock', {
-        hostname: 'http://127.0.0.1:4010/mock',
-        method: 'GET',
-        path,
-        statusCode: 200,
-        body: {
-          ...exampleTreeData,
-          photo_url: url,
-          status: 200,
-        },
-      });
+      Cypress.env('nock') &&
+        cy.task('nock', {
+          hostname: 'http://127.0.0.1:4010/mock',
+          method: 'GET',
+          path,
+          statusCode: 200,
+          body: {
+            ...exampleTreeData,
+            photo_url: url,
+            status: 200,
+          },
+        });
     });
     cy.visit(path);
     cy.contains(`${exampleTreeData.id}`);
@@ -55,7 +56,7 @@ const testImage = (fileName, imageType = 'image/jpg') => {
 };
 
 beforeEach(() => {
-  cy.task('clearNock');
+  Cypress.env('nock') && cy.task('clearNock');
 });
 
 describe('Image cases', () => {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev": "next dev",
     "dev:mock": "concurrently \"npm run mock-server\" \"npm run dev\"",
     "cy": "cypress open",
+    "cy:nock": "cypress open --env nock=true",
     "cyu": "cypress open-ct",
     "cyux": "rm -rf .next/; npm run cyu",
     "cypress:open": "cypress open",


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

This adds the option to open cypress without starting a nextjs server to use nock. `npm run cy` will now start cypress without nock. This means you will need to start the web server separately with `npm run dev` or `npm start`. To run cypress with nock (old behavior) use the new script `npm run cy:nock`. This sets a [cypress environment variable ](https://docs.cypress.io/guides/guides/environment-variables#Option-4-env) which can be used to check if the nock server is active. Previous uses of nock have been updated to skip if environment variable is not set. 

Fixes #337 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Cypress integration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
