### PR TITLE
style: add sandbox for colors and typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,18 @@ Our Figma design resource is here: https://www.figma.com/file/XdYFdjlsHvxehlrkPV
 
 Make sure you are logged in to Figma so that you can inspect the style details in Figma's editor.
 
+## Design Sandbox
+
+To access the projects design sandbox, please run Cypress unit/component tests:
+
+```
+npm run cyu
+```
+
+Open DesignSandbox.cy.js test file in the component test browser. This component will have a color swatch, background gradient swatch, and typography information that matches the project's design file.
+
+Please use colors from MUI's theme when working on the style of the project for better maintainability, at readability. DO NOT write colors manually!
+
 ## Code style guide
 
 We use [Prettier](https://prettier.io/), [Eslint](https://eslint.org/) along with [husky](https://typicode.github.io/husky/#/) to style our code.

--- a/src/DesignSandbox.cy.js
+++ b/src/DesignSandbox.cy.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { mountWithTheme as mount } from './models/test-utils';
+import DesignSandbox from './DesignSandbox';
+
+describe('designSandbox', () => {
+  it('it shows designSandbox', () => {
+    cy.viewport(867, 750);
+    mount(<DesignSandbox />);
+  });
+});

--- a/src/DesignSandbox.js
+++ b/src/DesignSandbox.js
@@ -1,0 +1,167 @@
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import * as React from 'react';
+import { styled , useTheme } from '@mui/material/styles';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell, { tableCellClasses } from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Paper from '@mui/material/Paper';
+
+const StyledTableCell = styled(TableCell)(({ theme }) => ({
+  [`&.${tableCellClasses.head}`]: {
+    backgroundColor: theme.palette.common.black,
+    color: theme.palette.common.white,
+  },
+  [`&.${tableCellClasses.body}`]: {
+    fontSize: 14,
+  },
+}));
+
+const StyledTableRow = styled(TableRow)(({ theme }) => ({
+  '&:nth-of-type(odd)': {
+    backgroundColor: theme.palette.action.hover,
+  },
+  // hide last border
+  '&:last-child td, &:last-child th': {
+    border: 0,
+  },
+}));
+
+const colorData = [
+  'primary',
+  'secondary',
+  'textPrimary',
+  'textSecondary',
+  'textAlternative',
+  'textLight',
+];
+
+const Row = ({ color, isBackground }) => (
+    <StyledTableRow>
+      <TableCell component="th" scope="row">
+        <Typography variant="h6">{color}</Typography>
+      </TableCell>
+      <TableCell align="right">
+        <Box
+          sx={{
+            height: 50,
+            width: 50,
+            borderRadius: '50%',
+            bgcolor: isBackground || `${color}.main`,
+            background: (theme) => theme.palette.background[color],
+          }}
+        ></Box>
+      </TableCell>
+    </StyledTableRow>
+  );
+
+const DesignSandbox = () => {
+  const theme = useTheme();
+  const bgData = Object.entries(theme.palette.background).map(
+    (entry) => entry[0],
+  );
+
+  return (
+    <div>
+      <Grid container justifyContent="space-around">
+        <Grid item>
+          <TableContainer component={Paper}>
+            <Table sx={{ maxWidth: 300 }} aria-label="customized table">
+              <TableHead>
+                <TableRow>
+                  <StyledTableCell>
+                    <Typography variant="h6">Color Swatch</Typography>
+                  </StyledTableCell>
+                  <StyledTableCell></StyledTableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {colorData.map((color) => (
+                  <Row key={color} color={color} />
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+        <Grid item>
+          <TableContainer component={Paper}>
+            <Table sx={{ maxWidth: 300 }} aria-label="customized table">
+              <TableHead>
+                <TableRow>
+                  <StyledTableCell>
+                    <Typography variant="h6">Background Swatch</Typography>
+                  </StyledTableCell>
+                  <StyledTableCell></StyledTableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {bgData.map((color) => (
+                  <Row key={color} color={color} isBackground />
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Grid>
+      </Grid>
+
+      <Box sx={{ width: '100%', maxWidth: 500 }}>
+        <Typography variant="h3" mt={4} mb={4}>
+          Typography:
+        </Typography>
+        <Typography variant="h1" component="div" gutterBottom>
+          h1. Heading 48px
+        </Typography>
+        <Typography variant="h2" gutterBottom component="div">
+          h2. Heading 36px
+        </Typography>
+        <Typography variant="h3" gutterBottom component="div">
+          h3. Heading 32px
+        </Typography>
+        <Typography variant="h4" gutterBottom component="div">
+          h4. Heading 28px
+        </Typography>
+        <Typography variant="h5" gutterBottom component="div">
+          h5. Heading 20px
+        </Typography>
+        <Typography variant="h6" gutterBottom component="div">
+          h6. Heading 16px
+        </Typography>
+        <Typography variant="subtitle1" gutterBottom component="div">
+          subtitle1. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+          Quos blanditiis tenetur
+        </Typography>
+        <Typography variant="subtitle2" gutterBottom component="div">
+          subtitle2. Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+          Quos blanditiis tenetur
+        </Typography>
+        <Typography variant="body1" gutterBottom>
+          body1. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos
+          blanditiis tenetur unde suscipit, quam beatae rerum inventore
+          consectetur, neque doloribus, cupiditate numquam dignissimos laborum
+          fugiat deleniti? Eum quasi quidem quibusdam.
+        </Typography>
+        <Typography variant="body2" gutterBottom>
+          body2. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quos
+          blanditiis tenetur unde suscipit, quam beatae rerum inventore
+          consectetur, neque doloribus, cupiditate numquam dignissimos laborum
+          fugiat deleniti? Eum quasi quidem quibusdam.
+        </Typography>
+        <Typography variant="button" display="block" gutterBottom>
+          button text
+        </Typography>
+        <Typography variant="caption" display="block" gutterBottom>
+          caption text
+        </Typography>
+        <Typography variant="overline" display="block" gutterBottom>
+          overline text
+        </Typography>
+      </Box>
+    </div>
+  );
+};
+
+export default DesignSandbox;

--- a/src/components/BackButton.js
+++ b/src/components/BackButton.js
@@ -1,26 +1,12 @@
 import ArrowBackIosIcon from '@mui/icons-material/ArrowBackIos';
-import { ButtonBase } from '@mui/material';
-import { makeStyles } from 'models/makeStyles';
+import { ButtonBase, Typography } from '@mui/material';
 import React from 'react';
 
-const useStyles = makeStyles()(() => ({
-  backButton: {
-    textTransform: 'none',
-    fontSize: 16,
-    lineHeight: '16px',
-    color: '#6B6E70',
-  },
-  icon: {
-    marginRight: -4,
-  },
-}));
-
 export default function BackButton() {
-  const { classes } = useStyles();
   return (
-    <ButtonBase className={classes.backButton} color="textPrimary">
-      <ArrowBackIosIcon fontSize="inherit" className={classes.icon} />
-      Back
+    <ButtonBase sx={{ color: 'textLight.main' }}>
+      <ArrowBackIosIcon fontSize="inherit" />
+      <Typography variant="body1">Back</Typography>
     </ButtonBase>
   );
 }

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -55,7 +55,7 @@ const useStyles = makeStyles()((theme) => ({
   },
   findATreeButton: {
     textTransform: 'none',
-    background: theme.palette.success.main,
+    background: theme.palette.secondary.main,
   },
 }));
 
@@ -64,7 +64,7 @@ export default function Home() {
 
   const Buttons = () => (
     <Box className={classes.buttonsContainer}>
-      <Button variant="outlined" color="primary" className={classes.button}>
+      <Button variant="outlined" color="inherit" className={classes.button}>
         Learn more
       </Button>
       <Link href="/top">

--- a/src/components/InformationCard1.js
+++ b/src/components/InformationCard1.js
@@ -1,4 +1,4 @@
-import { Box, Button, CardMedia } from '@mui/material';
+import { Box, Button, CardMedia, Typography } from '@mui/material';
 import { makeStyles } from 'models/makeStyles';
 import React from 'react';
 import Link from './Link';
@@ -8,8 +8,7 @@ const useStyles = makeStyles()((theme) => ({
     boxSizing: 'border-box',
     height: 220,
     padding: '25px 30px',
-    background:
-      'linear-gradient(120.41deg, rgba(255, 122, 0, 0.15) 25.62%, rgba(117, 185, 38, 0.4) 97.96%)',
+    background: theme.palette.background.greenOrangeLightGr,
     borderRadius: '15px',
   },
   contentWrapper: {
@@ -19,10 +18,8 @@ const useStyles = makeStyles()((theme) => ({
   button: {
     height: 45,
     borderRadius: '25px',
-    background:
-      'linear-gradient(90.06deg, rgba(255, 165, 0, 0.45) 0.79%, rgba(117, 185, 38, 0.45) 49.97%, rgba(96, 137, 47, 0.6) 99.95%)',
+    background: theme.palette.background.OrangeGreenGradient,
     boxShadow: '0px 8px 16px rgba(97, 137, 47, 0.25)',
-    fontWeight: 700,
     textTransform: 'none',
   },
   media: {
@@ -77,7 +74,7 @@ function InformationCard1({
       </div>
       <Link href={link}>
         <Button className={classes.button} fullWidth={true}>
-          {buttonText}
+          <Typography variant="h5">{buttonText}</Typography>
         </Button>
       </Link>
     </Box>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -19,7 +19,7 @@ const logo = '/images/greenstand_logo_full.png';
 
 const useStyles = makeStyles()((theme) => ({
   navContainer: {
-    backgroundColor: '#ffffff',
+    backgroundColor: theme.palette.background.default,
     height: 72,
     width: '100vw',
     flexDirection: 'row',

--- a/src/components/SearchButton.js
+++ b/src/components/SearchButton.js
@@ -1,23 +1,14 @@
 import SearchIcon from '@mui/icons-material/Search';
 import Fab from '@mui/material/Fab';
-import { makeStyles } from 'models/makeStyles';
 import React from 'react';
 
-const useStyles = makeStyles()(() => ({
-  fab: {
-    height: 48,
-    width: 48,
-  },
-  icon: {
-    color: '#6B6E70',
-  },
-}));
-
 export default function SearchButton() {
-  const { classes } = useStyles();
   return (
-    <Fab aria-label="search" color="primary" className={classes.fab}>
-      <SearchIcon fontSize="large" className={classes.icon} />
+    <Fab
+      aria-label="search"
+      sx={{ height: 48, width: 48, bgcolor: 'background.default' }}
+    >
+      <SearchIcon fontSize="large" sx={{ color: 'textLight.main' }} />
     </Fab>
   );
 }

--- a/src/components/TreeSpeciesCard.js
+++ b/src/components/TreeSpeciesCard.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Card from '@mui/material/Card';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'models/makeStyles';
 
 const useStyles = makeStyles()((theme) => ({
@@ -11,8 +10,7 @@ const useStyles = makeStyles()((theme) => ({
     boxSizing: 'border-box',
     borderRadius: theme.spacing(4),
     border: '1px solid',
-    borderColor: theme.palette.grey[600],
-    width: '60%',
+    borderColor: theme.palette.textLight.main,
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -20,7 +18,7 @@ const useStyles = makeStyles()((theme) => ({
     marginBottom: theme.spacing(4),
   },
   countBox: {
-    background: theme.palette.grey[600],
+    background: theme.palette.textLight.main,
     color: theme.palette.common.white,
     padding: theme.spacing(5),
     display: 'flex',
@@ -31,23 +29,21 @@ const useStyles = makeStyles()((theme) => ({
 
 const TreeSpeciesCard = (props) => {
   const { classes } = useStyles();
-  const theme = useTheme();
 
   const { name, count } = props;
 
   return (
     <Card className={classes.root} elevation={0}>
       <Box ml={5}>
-        <Typography
-          variant="body1"
-          sx={{ color: theme.palette.textPrimary.main, fontWeight: 600 }}
-        >
+        <Typography variant="h5" sx={{ color: 'textPrimary.main' }}>
           {name}
         </Typography>
       </Box>
       <Box className={classes.countBox}>
         <Typography variant="body1">Count:</Typography>
-        <Typography variant="h6">{count}</Typography>
+        <Typography variant="h5" sx={{ fontSize: 28 }}>
+          {count}
+        </Typography>
       </Box>
     </Card>
   );

--- a/src/components/VerifiedBadge.js
+++ b/src/components/VerifiedBadge.js
@@ -1,20 +1,16 @@
 import CheckIcon from '@mui/icons-material/Check';
 import { Chip } from '@mui/material';
-import { makeStyles } from 'models/makeStyles';
 import React from 'react';
 
-const useStyles = makeStyles()(() => ({
-  chip: {
-    borderRadius: '4px',
-  },
-}));
-
 function VerifiedBadge({ verified, badgeName }) {
-  const { classes } = useStyles();
   return (
     <Chip
-      className={classes.chip}
-      color={!verified ? 'primary' : 'secondary'}
+      color="primary"
+      sx={{
+        bgcolor: verified ? 'primary.main' : 'textPrimary.main',
+        color: 'common.white',
+        borderRadius: 1,
+      }}
       size="small"
       icon={!verified ? null : <CheckIcon />}
       label={badgeName}

--- a/src/components/common/CustomCard.js
+++ b/src/components/common/CustomCard.js
@@ -34,17 +34,17 @@ const CustomCard = (props) => {
       sx={{
         background: disabled
           ? theme.palette.grey[300]
-          : theme.palette.background.greenBg,
+          : theme.palette.background.greenGradient,
       }}
     >
       <CardMedia sx={{ padding: theme.spacing(4) }}>
         <Avatar
           sx={{
+            height: 60,
+            width: 60,
             boxShadow: disabled ? '' : '0px 6px 12px 0px #585B5D40',
             backgroundColor: 'white',
-            color: disabled
-              ? theme.palette.textSecondary.main
-              : theme.palette.success.main,
+            color: disabled ? 'textSecondary.main' : 'secondary.main',
           }}
         >
           {icon}
@@ -53,12 +53,10 @@ const CustomCard = (props) => {
       <CardContent
         sx={{ display: 'flex', flexDirection: 'column', paddingLeft: 0 }}
       >
-        <Typography className={classes.title} color="textSecondary">
+        <Typography variant="body1" color="textSecondary">
           {title}
         </Typography>
-        <Typography variant="h5" component="h2">
-          {text}
-        </Typography>
+        <Typography variant="h2">{text}</Typography>
       </CardContent>
     </Card>
   );

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -23,7 +23,6 @@ import moment from 'moment';
 import TreeSpeciesCard from 'components/TreeSpeciesCard';
 import CustomCard from '../../components/common/CustomCard';
 
-
 // make styles for component with material-ui
 const useStyles = makeStyles()((theme) => ({
   root: {
@@ -46,38 +45,6 @@ const useStyles = makeStyles()((theme) => ({
       marginRight: 8,
     },
   },
-  title: {
-    fontFamily: 'Montserrat',
-    fontStyle: 'normal',
-    fontWeight: 'bold',
-    fontSize: '36px',
-    lineHeight: '44px',
-    display: 'flex',
-    alignItems: 'center',
-    color: '#474B4F',
-  },
-  title3: {
-    fontFamily: 'Montserrat',
-    fontStyle: 'normal',
-    fontWeight: '500',
-    fontSize: '24px',
-    lineHeight: '29px',
-    display: 'flex',
-    alignItems: 'center',
-    color: '#474B4F',
-    marginTop: theme.spacing(10),
-  },
-  title4: {
-    fontFamily: 'Montserrat',
-    fontStyle: 'normal',
-    fontWeight: '500',
-    fontSize: '24px',
-    lineHeight: '29px',
-    display: 'flex',
-    alignItems: 'center',
-    color: '#474B4F',
-    marginTop: theme.spacing(28),
-  },
   treeSlider: {
     marginTop: theme.spacing(10),
   },
@@ -85,27 +52,6 @@ const useStyles = makeStyles()((theme) => ({
     marginLeft: theme.spacing(-10),
     marginRight: theme.spacing(-10),
     width: '100%',
-  },
-  title5: {
-    fontFamily: 'Montserrat',
-    fontStyle: 'normal',
-    fontWeight: '600',
-    fontSize: '28px',
-    lineHeight: '34px',
-    display: 'flex',
-    alignItems: 'center',
-    color: '#474B4F',
-  },
-  text1: {
-    fontFamily: 'Lato',
-    fontStyle: 'normal',
-    fontWeight: 'normal',
-    fontSize: '20px',
-    lineHeight: '28px',
-    display: 'flex',
-    alignItems: 'center',
-    letterSpacing: '0.04em',
-    color: '#474B4F',
   },
 }));
 
@@ -140,7 +86,7 @@ export default function Planter({ planter }) {
 
   return (
     <PageWrapper className={classes.root}>
-      <Typography variant="h6" className={classes.title}>
+      <Typography variant="h2" sx={{ color: 'textPrimary.main' }}>
         {planter.first_name} {planter.last_name}
       </Typography>
       <Box className={classes.badges}>
@@ -173,7 +119,7 @@ export default function Planter({ planter }) {
         <Grid item>
           <CustomCard
             handleClick={handleCardClick}
-            icon={<ParkOutlinedIcon />}
+            icon={<ParkOutlinedIcon fontSize="large" />}
             title="Trees Planted"
             text={planter.featuredTrees.total}
             disabled={isPlanterTab ? false : true}
@@ -185,7 +131,7 @@ export default function Planter({ planter }) {
         <Grid item>
           <CustomCard
             handleClick={handleCardClick}
-            icon={<GroupsOutlinedIcon />}
+            icon={<GroupsOutlinedIcon fontSize="large" />}
             title="Associated Organizations"
             text={planter.associatedOrganizations.total}
             disabled={!isPlanterTab ? false : true}
@@ -194,7 +140,10 @@ export default function Planter({ planter }) {
       </Grid>
       {isPlanterTab && (
         <>
-          <Typography variant="h3" className={classes.title3}>
+          <Typography
+            variant="h4"
+            sx={{ fontSize: 24, color: 'textPrimary.main' }}
+          >
             Explore some trees planted by <strong>{planter.first_name}</strong>
           </Typography>
           <Box className={classes.treeSlider}>
@@ -214,7 +163,7 @@ export default function Planter({ planter }) {
             />
           </div>
         ))}
-      <Typography variant="h6" className={classes.title4}>
+      <Typography variant="h4" sx={{ fontSize: 24, color: 'textPrimary.main' }}>
         Species of trees planted
       </Typography>
       <Box className={classes.speciesBox}>
@@ -230,19 +179,19 @@ export default function Planter({ planter }) {
       <Box mt={10} />
       <Divider className={classes.divider} />
       <Box mt={20} />
-      <Typography variant="h6" className={classes.title5}>
+      <Typography variant="h4" sx={{ color: 'textPrimary.main' }}>
         About
       </Typography>
       <Box mt={7} />
-      <Typography variant="body1" className={classes.text1}>
+      <Typography variant="body1" sx={{ color: 'textPrimary.main' }}>
         {planter.about}
       </Typography>
       <Box mt={16} />
-      <Typography variant="h6" className={classes.title5}>
+      <Typography variant="h4" sx={{ color: 'textPrimary.main' }}>
         Mission
       </Typography>
       <Box mt={7} />
-      <Typography variant="body1" className={classes.text1}>
+      <Typography variant="body1" sx={{ color: 'textPrimary.main' }}>
         {planter.mission}
       </Typography>
       <Box mt={20} />

--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -19,9 +19,6 @@ const useStyles = makeStyles()((theme) => ({
     alignItems: 'flex-start',
     justifyContent: 'flex-start',
   },
-  title: {
-    color: '#474B4F',
-  },
   imageContainer: {
     position: 'relative',
     flexGrow: 1,
@@ -42,9 +39,6 @@ const useStyles = makeStyles()((theme) => ({
   },
   title2: {
     marginTop: theme.spacing(26),
-    fontFamily: 'Montserrat',
-    fontStyle: 'normal',
-    fontWeight: '600',
     fontSize: '28px',
     lineHeight: '34px',
     display: 'flex',
@@ -54,7 +48,7 @@ const useStyles = makeStyles()((theme) => ({
   },
   tabBox: {
     marginTop: theme.spacing(9),
-    flexWrap: "wrap",
+    flexWrap: 'wrap',
     display: 'flex',
     '& div': {
       margin: theme.spacing(1),
@@ -65,6 +59,7 @@ const useStyles = makeStyles()((theme) => ({
 export default function Tree({ tree, planter, organization }) {
   const { classes } = useStyles();
   const mapContext = useMapContext();
+  console.log(tree);
 
   log.warn('map:', mapContext);
 
@@ -76,14 +71,14 @@ export default function Tree({ tree, planter, organization }) {
   }, [mapContext.map]);
 
   const Title = () => (
-    <Typography className={classes.title} variant="h2">
+    <Typography sx={{ color: 'textPrimary.main' }} variant="h2">
       Tree{/* tree.species */} - #{tree.id}
     </Typography>
   );
 
   const Badges = () => (
     <Box className={classes.badges}>
-      <VerifiedBadge verified={tree.approved} badgeName="Tree Verified" />
+      <VerifiedBadge verified={tree.verified} badgeName="Tree Verified" />
       <VerifiedBadge verified={tree.token_id} badgeName="Token Issued" />
     </Box>
   );
@@ -105,20 +100,15 @@ export default function Tree({ tree, planter, organization }) {
   return (
     <PageWrapper className={classes.root}>
       <Title />
-      <Typography className={classes.title} variant="h4">
+      <Typography
+        sx={{ color: 'textPrimary.main', fontWeight: 300 }}
+        variant="h5"
+      >
         Eco-Peace-Vision
       </Typography>
       <Badges />
       <TreeImage />
-      <Box className={classes.informationCard}>
-        <InformationCard1
-          entityName={`${planter.first_name} ${planter.last_name}`}
-          entityType={'Planter'}
-          buttonText={'Meet the Planter'}
-          cardImageSrc={planter?.photo_url}
-          link={`/planters/${planter.id}`}
-        />
-      </Box>
+
       <Box className={classes.informationCard}>
         <InformationCard1
           entityName={organization.name}
@@ -126,6 +116,15 @@ export default function Tree({ tree, planter, organization }) {
           buttonText={'Meet the Organization'}
           cardImageSrc={organization?.photo_url}
           link={`/organizations/${organization.id}`}
+        />
+      </Box>
+      <Box className={classes.informationCard}>
+        <InformationCard1
+          entityName={`${planter.first_name} ${planter.last_name}`}
+          entityType={'Planter'}
+          buttonText={'Meet the Planter'}
+          cardImageSrc={planter?.photo_url}
+          link={`/planters/${planter.id}`}
         />
       </Box>
       <Typography variant="h4" className={classes.title2}>

--- a/src/theme.js
+++ b/src/theme.js
@@ -13,67 +13,69 @@ const theme = createTheme({
     h1: {
       fontFamily: ['Montserrat'].join(','),
       fontSize: '48px',
-      fontWeight: 700,
+      fontWeight: 600,
       lineHeight: '63px',
     },
     h2: {
       fontFamily: 'Montserrat',
       fontSize: '36px',
       lineHeight: '44px',
-      fontWeight: 700,
+      fontWeight: 600,
     },
     h3: {
       fontFamily: 'Montserrat',
-      fontSize: '20px',
+      fontSize: '32px',
       lineHeight: '28px',
-      fontWeight: 700,
+      fontWeight: 600,
     },
     h4: {
       fontFamily: 'Montserrat',
-      fontSize: '20px',
-      fontWeight: 400,
+      fontSize: '28px',
+      fontWeight: 700,
     },
     h5: {
-      fontFamily: 'Montserrat',
+      fontSize: '20px',
       fontWeight: 700,
     },
     h6: {
-      fontFamily: 'Montserrat',
+      fontSize: '16px',
       fontWeight: 700,
     },
-    subtitle1: {
-      fontSize: 36,
-      fontWeight: 700,
-      color: '#474B4F',
-    },
-    subtitle2: {
-      fontSize: 24,
-      fontWeight: 700,
-      color: '#474B4F',
+    body1: {
+      letterSpacing: '0.04em',
     },
   },
   palette: {
     background: {
-      default: '#FFFFFF',
-      greenBg:
+      greenGradient:
         'linear-gradient(291.29deg, rgba(134, 194, 50, 0.65) 14.04%, rgba(134, 194, 50, 0.4) 86%, rgba(134, 194, 50, 0.45) 86%)',
+      greenOrangeLightGr:
+        'linear-gradient(291.56deg, rgba(255, 122, 0, 0.4) 0%, rgba(117, 185, 38, 0.15) 98.94%)',
+      greenOrangeLightGrInverse:
+        'linear-gradient(111.41deg, rgba(255, 122, 0, 0.15) 1.62%, rgba(117, 185, 38, 0.4) 98.96%)',
+      OrangeGreenGradient:
+        'linear-gradient(90.06deg, rgba(255, 165, 0, 0.45) 0.79%, rgba(117, 185, 38, 0.45) 49.97%, rgba(96, 137, 47, 0.6) 99.95%)',
+      OrangeGreenGradientDark:
+        'linear-gradient(90deg, rgba(255, 165, 0, 0.225) 0%, rgba(255, 122, 0, 0.2625) 48.96%, rgba(134, 194, 64, 0.45) 100%)',
     },
     primary: {
       main: '#61892F',
     },
     secondary: {
-      main: '#61892F',
-    },
-    success: {
       main: '#86C232',
     },
     textPrimary: {
-      main: '#373A3E',
+      main: '#474B4F',
     },
     textSecondary: {
-      main: '#848484',
+      main: '#222629',
     },
-    lightGreen: '#86C232',
+    textAlternative: {
+      main: '#373A3E',
+    },
+    textLight: {
+      main: '#6B6E70',
+    },
   },
 });
 


### PR DESCRIPTION
# Description

Suggestions and ideas are welcome with the naming of the colors or anything that seems can be arranged into a more logical order. Not sure about file placement. But that's what I came up with which organizes the colors and the typography of the project.

Adjusted the colors and typography in the project according to this style sheet. 
![Screenshot from 2021-12-05 14-55-07](https://user-images.githubusercontent.com/31432331/144751258-993ff76a-0d50-4260-bade-5afd668bc62c.png)

![Screenshot from 2021-12-05 14-55-10](https://user-images.githubusercontent.com/31432331/144751305-ccf1cda9-80f9-46e7-9cc4-32e375e01dde.png)

Parts that I did not change: 
TreeAge component: I will fix this in #302
Organization Page: I will raise a separate issue for this, as this page is really behind the others.
Time and Location component: These two components are basically the same. I think they should be merged into one component. If that's ok I will raise an issue for this as well, (I'm halfway done with this.)



Fixes #301 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Cypress component tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
