### PR TITLE
fix: security audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3787,9 +3787,9 @@
       "integrity": "sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA=="
     },
     "node_modules/@next/env": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.2.tgz",
-      "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA=="
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.3.tgz",
+      "integrity": "sha512-5+vaeooJuWmICSlmVaAC8KG3O8hwKasACVfkHj58xQuCB5SW0TKW3hWxgxkBuefMBn1nM0yEVPKokXCsYjBtng=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "11.1.2",
@@ -3801,14 +3801,14 @@
       }
     },
     "node_modules/@next/polyfill-module": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.2.tgz",
-      "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA=="
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.3.tgz",
+      "integrity": "sha512-7yr9cr4a0SrBoVE8psxXWK1wTFc8UzsY8Wc2cWGL7qA0hgtqACHaXC47M1ByJB410hFZenGrpE+KFaT1unQMyw=="
     },
     "node_modules/@next/react-dev-overlay": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.2.tgz",
-      "integrity": "sha512-rDF/mGY2NC69mMg2vDqzVpCOlWqnwPUXB2zkARhvknUHyS6QJphPYv9ozoPJuoT/QBs49JJd9KWaAzVBvq920A==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.3.tgz",
+      "integrity": "sha512-zIwtMliSUR+IKl917ToFNB+0fD7bI5kYMdjHU/UEKpfIXAZPnXRHHISCvPDsczlr+bRsbjlUFW1CsNiuFedeuQ==",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -3953,9 +3953,9 @@
       }
     },
     "node_modules/@next/react-refresh-utils": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.2.tgz",
-      "integrity": "sha512-hsoJmPfhVqjZ8w4IFzoo8SyECVnN+8WMnImTbTKrRUHOVJcYMmKLL7xf7T0ft00tWwAl/3f3Q3poWIN2Ueql/Q==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.3.tgz",
+      "integrity": "sha512-144kD8q2nChw67V3AJJlPQ6NUJVFczyn10bhTynn9o2rY5DEnkzuBipcyMuQl2DqfxMkV7sn+yOCOYbrLCk9zg==",
       "peerDependencies": {
         "react-refresh": "0.8.3",
         "webpack": "^4 || ^5"
@@ -3967,9 +3967,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.2.tgz",
-      "integrity": "sha512-hZuwOlGOwBZADA8EyDYyjx3+4JGIGjSHDHWrmpI7g5rFmQNltjlbaefAbiU5Kk7j3BUSDwt30quJRFv3nyJQ0w==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.3.tgz",
+      "integrity": "sha512-TwP4krjhs+uU9pesDYCShEXZrLSbJr78p12e7XnLBBaNf20SgWLlVmQUT9gX9KbWan5V0sUbJfmcS8MRNHgYuA==",
       "cpu": [
         "arm64"
       ],
@@ -3982,9 +3982,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.2.tgz",
-      "integrity": "sha512-PGOp0E1GisU+EJJlsmJVGE+aPYD0Uh7zqgsrpD3F/Y3766Ptfbe1lEPPWnRDl+OzSSrSrX1lkyM/Jlmh5OwNvA==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.3.tgz",
+      "integrity": "sha512-ZSWmkg/PxccHFNUSeBdrfaH8KwSkoeUtewXKvuYYt7Ph0yRsbqSyNIvhUezDua96lApiXXq6EL2d1THfeWomvw==",
       "cpu": [
         "x64"
       ],
@@ -3997,9 +3997,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.2.tgz",
-      "integrity": "sha512-YcDHTJjn/8RqvyJVB6pvEKXihDcdrOwga3GfMv/QtVeLphTouY4BIcEUfrG5+26Nf37MP1ywN3RRl1TxpurAsQ==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.3.tgz",
+      "integrity": "sha512-PrTBN0iZudAuj4jSbtXcdBdmfpaDCPIneG4Oms4zcs93KwMgLhivYW082Mvlgx9QVEiRm7+RkFpIVtG/i7JitA==",
       "cpu": [
         "x64"
       ],
@@ -4012,9 +4012,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.2.tgz",
-      "integrity": "sha512-e/pIKVdB+tGQYa1cW3sAeHm8gzEri/HYLZHT4WZojrUxgWXqx8pk7S7Xs47uBcFTqBDRvK3EcQpPLf3XdVsDdg==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.3.tgz",
+      "integrity": "sha512-mRwbscVjRoHk+tDY7XbkT5d9FCwujFIQJpGp0XNb1i5OHCSDO8WW/C9cLEWS4LxKRbIZlTLYg1MTXqLQkvva8w==",
       "cpu": [
         "x64"
       ],
@@ -16031,16 +16031,16 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-11.1.2.tgz",
-      "integrity": "sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-11.1.3.tgz",
+      "integrity": "sha512-ud/gKmnKQ8wtHC+pd1ZiqPRa7DdgulPkAk94MbpsspfNliwZkYs9SIYWhlLSyg+c661LzdUI2nZshvrtggSYWA==",
       "dependencies": {
         "@babel/runtime": "7.15.3",
         "@hapi/accept": "5.0.2",
-        "@next/env": "11.1.2",
-        "@next/polyfill-module": "11.1.2",
-        "@next/react-dev-overlay": "11.1.2",
-        "@next/react-refresh-utils": "11.1.2",
+        "@next/env": "11.1.3",
+        "@next/polyfill-module": "11.1.3",
+        "@next/react-dev-overlay": "11.1.3",
+        "@next/react-refresh-utils": "11.1.3",
         "@node-rs/helper": "1.2.1",
         "assert": "2.0.0",
         "ast-types": "0.13.2",
@@ -16093,10 +16093,10 @@
         "node": ">=12.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "11.1.2",
-        "@next/swc-darwin-x64": "11.1.2",
-        "@next/swc-linux-x64-gnu": "11.1.2",
-        "@next/swc-win32-x64-msvc": "11.1.2"
+        "@next/swc-darwin-arm64": "11.1.3",
+        "@next/swc-darwin-x64": "11.1.3",
+        "@next/swc-linux-x64-gnu": "11.1.3",
+        "@next/swc-win32-x64-msvc": "11.1.3"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -25016,9 +25016,9 @@
       "integrity": "sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA=="
     },
     "@next/env": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.2.tgz",
-      "integrity": "sha512-+fteyVdQ7C/OoulfcF6vd1Yk0FEli4453gr8kSFbU8sKseNSizYq6df5MKz/AjwLptsxrUeIkgBdAzbziyJ3mA=="
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-11.1.3.tgz",
+      "integrity": "sha512-5+vaeooJuWmICSlmVaAC8KG3O8hwKasACVfkHj58xQuCB5SW0TKW3hWxgxkBuefMBn1nM0yEVPKokXCsYjBtng=="
     },
     "@next/eslint-plugin-next": {
       "version": "11.1.2",
@@ -25030,14 +25030,14 @@
       }
     },
     "@next/polyfill-module": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.2.tgz",
-      "integrity": "sha512-xZmixqADM3xxtqBV0TpAwSFzWJP0MOQzRfzItHXf1LdQHWb0yofHHC+7eOrPFic8+ZGz5y7BdPkkgR1S25OymA=="
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-11.1.3.tgz",
+      "integrity": "sha512-7yr9cr4a0SrBoVE8psxXWK1wTFc8UzsY8Wc2cWGL7qA0hgtqACHaXC47M1ByJB410hFZenGrpE+KFaT1unQMyw=="
     },
     "@next/react-dev-overlay": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.2.tgz",
-      "integrity": "sha512-rDF/mGY2NC69mMg2vDqzVpCOlWqnwPUXB2zkARhvknUHyS6QJphPYv9ozoPJuoT/QBs49JJd9KWaAzVBvq920A==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-11.1.3.tgz",
+      "integrity": "sha512-zIwtMliSUR+IKl917ToFNB+0fD7bI5kYMdjHU/UEKpfIXAZPnXRHHISCvPDsczlr+bRsbjlUFW1CsNiuFedeuQ==",
       "requires": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -25150,33 +25150,33 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.2.tgz",
-      "integrity": "sha512-hsoJmPfhVqjZ8w4IFzoo8SyECVnN+8WMnImTbTKrRUHOVJcYMmKLL7xf7T0ft00tWwAl/3f3Q3poWIN2Ueql/Q==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.3.tgz",
+      "integrity": "sha512-144kD8q2nChw67V3AJJlPQ6NUJVFczyn10bhTynn9o2rY5DEnkzuBipcyMuQl2DqfxMkV7sn+yOCOYbrLCk9zg==",
       "requires": {}
     },
     "@next/swc-darwin-arm64": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.2.tgz",
-      "integrity": "sha512-hZuwOlGOwBZADA8EyDYyjx3+4JGIGjSHDHWrmpI7g5rFmQNltjlbaefAbiU5Kk7j3BUSDwt30quJRFv3nyJQ0w==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.3.tgz",
+      "integrity": "sha512-TwP4krjhs+uU9pesDYCShEXZrLSbJr78p12e7XnLBBaNf20SgWLlVmQUT9gX9KbWan5V0sUbJfmcS8MRNHgYuA==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.2.tgz",
-      "integrity": "sha512-PGOp0E1GisU+EJJlsmJVGE+aPYD0Uh7zqgsrpD3F/Y3766Ptfbe1lEPPWnRDl+OzSSrSrX1lkyM/Jlmh5OwNvA==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.3.tgz",
+      "integrity": "sha512-ZSWmkg/PxccHFNUSeBdrfaH8KwSkoeUtewXKvuYYt7Ph0yRsbqSyNIvhUezDua96lApiXXq6EL2d1THfeWomvw==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.2.tgz",
-      "integrity": "sha512-YcDHTJjn/8RqvyJVB6pvEKXihDcdrOwga3GfMv/QtVeLphTouY4BIcEUfrG5+26Nf37MP1ywN3RRl1TxpurAsQ==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.3.tgz",
+      "integrity": "sha512-PrTBN0iZudAuj4jSbtXcdBdmfpaDCPIneG4Oms4zcs93KwMgLhivYW082Mvlgx9QVEiRm7+RkFpIVtG/i7JitA==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.2.tgz",
-      "integrity": "sha512-e/pIKVdB+tGQYa1cW3sAeHm8gzEri/HYLZHT4WZojrUxgWXqx8pk7S7Xs47uBcFTqBDRvK3EcQpPLf3XdVsDdg==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.3.tgz",
+      "integrity": "sha512-mRwbscVjRoHk+tDY7XbkT5d9FCwujFIQJpGp0XNb1i5OHCSDO8WW/C9cLEWS4LxKRbIZlTLYg1MTXqLQkvva8w==",
       "optional": true
     },
     "@node-rs/helper": {
@@ -34446,20 +34446,20 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "next": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/next/-/next-11.1.2.tgz",
-      "integrity": "sha512-azEYL0L+wFjv8lstLru3bgvrzPvK0P7/bz6B/4EJ9sYkXeW8r5Bjh78D/Ol7VOg0EIPz0CXoe72hzAlSAXo9hw==",
+      "version": "11.1.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-11.1.3.tgz",
+      "integrity": "sha512-ud/gKmnKQ8wtHC+pd1ZiqPRa7DdgulPkAk94MbpsspfNliwZkYs9SIYWhlLSyg+c661LzdUI2nZshvrtggSYWA==",
       "requires": {
         "@babel/runtime": "7.15.3",
         "@hapi/accept": "5.0.2",
-        "@next/env": "11.1.2",
-        "@next/polyfill-module": "11.1.2",
-        "@next/react-dev-overlay": "11.1.2",
-        "@next/react-refresh-utils": "11.1.2",
-        "@next/swc-darwin-arm64": "11.1.2",
-        "@next/swc-darwin-x64": "11.1.2",
-        "@next/swc-linux-x64-gnu": "11.1.2",
-        "@next/swc-win32-x64-msvc": "11.1.2",
+        "@next/env": "11.1.3",
+        "@next/polyfill-module": "11.1.3",
+        "@next/react-dev-overlay": "11.1.3",
+        "@next/react-refresh-utils": "11.1.3",
+        "@next/swc-darwin-arm64": "11.1.3",
+        "@next/swc-darwin-x64": "11.1.3",
+        "@next/swc-linux-x64-gnu": "11.1.3",
+        "@next/swc-win32-x64-msvc": "11.1.3",
         "@node-rs/helper": "1.2.1",
         "assert": "2.0.0",
         "ast-types": "0.13.2",


### PR DESCRIPTION
# Description

here's a fix for the new security warning that shows up with `npm audit --production`.

```
next  <11.1.3
Severity: high
Unexpected server crash in Next.js - https://github.com/advisories/GHSA-25mp-g6fv-mqxx
fix available via `npm audit fix`
node_modules/next
```