### PR TITLE
Issue #344 mobile design

### DIFF
--- a/.github/ISSUE_TEMPLATE/basic-issue.md
+++ b/.github/ISSUE_TEMPLATE/basic-issue.md
@@ -4,7 +4,6 @@ about: Almost a blank issue with some generic guides/hints.
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/component-building.md
+++ b/.github/ISSUE_TEMPLATE/component-building.md
@@ -4,7 +4,6 @@ about: This issue is about building component.s
 title: ''
 labels: MaterialUI, react
 assignees: ''
-
 ---
 
 ---

--- a/doc/web-map-api.yaml
+++ b/doc/web-map-api.yaml
@@ -55,7 +55,7 @@ paths:
       operationId: trees
       description: |-
         query trees by filters like planter, also consider pagination
-        I think filter all tree by `active = true` is by default 
+        I think filter all tree by `active = true` is by default
       parameters:
         - schema:
             type: integer
@@ -425,12 +425,12 @@ paths:
           in: query
           name: planter_id
           description: Filter by planter id
-      description: 'mainly if we can provide this endpoint, then we can display a species list on org or planter page, but I don''t know if it is too resource consumming to query DB'
+      description: "mainly if we can provide this endpoint, then we can display a species list on org or planter page, but I don't know if it is too resource consumming to query DB"
   /transactions:
     get:
       summary: get token transaction list by filter/parameters
       operationId: get-transactions
-      description: 'about returning wallet name, it is a pretty common use case that we need to display the wallet name in the frontend, so we''d better join and return the name of wallet'
+      description: "about returning wallet name, it is a pretty common use case that we need to display the wallet name in the frontend, so we'd better join and return the name of wallet"
       responses:
         '200':
           description: OK
@@ -527,12 +527,12 @@ paths:
             type: boolean
           in: query
           name: withCapture
-          description: 'if we need show a token list, it''s usually we need display the tree linked to the token, and the planter info, and I think make this configurable might be better, so I add this switcher'
+          description: "if we need show a token list, it's usually we need display the tree linked to the token, and the planter info, and I think make this configurable might be better, so I add this switcher"
         - schema:
             type: string
           in: query
           name: withPlanter
-          description: 'if we need show a token list, it''s usually we need display the tree linked to the token, and the planter info, and I think make this configurable might be better, so I add this switcher'
+          description: "if we need show a token list, it's usually we need display the tree linked to the token, and the planter info, and I think make this configurable might be better, so I add this switcher"
       description: ''
   '/wallets/{walletIdOrName}':
     get:
@@ -854,7 +854,7 @@ components:
           type: number
         capture_id:
           type: string
-          description: 'In the public.trees table, it''s the uuid column'
+          description: "In the public.trees table, it's the uuid column"
         capture_approval_tag:
           type: string
         domain_specific_data:
@@ -898,7 +898,7 @@ components:
           type: string
         location?:
           type: string
-          description: 'I don''t know if we can provide this infomation, the city/country of the planter, could be removed if impossible'
+          description: "I don't know if we can provide this infomation, the city/country of the planter, could be removed if impossible"
         links:
           type: object
           properties:
@@ -941,7 +941,7 @@ components:
           description: 'kind of like a cover photo, Seb says he will find a way to populate it, maybe manually in ealy stage'
         location?:
           type: string
-          description: 'I don''t know if we can provide this infomation, the city/country of the org, could be removed if impossible'
+          description: "I don't know if we can provide this infomation, the city/country of the org, could be removed if impossible"
         created_at:
           type: string
         about:
@@ -978,7 +978,7 @@ components:
           type: string
         count:
           type: integer
-          description: 'It would be great if we can display how many trees in this species has been planted by org or planter, but I don''t know if it is too resource consumming to query DB'
+          description: "It would be great if we can display how many trees in this species has been planted by org or planter, but I don't know if it is too resource consumming to query DB"
     transaction:
       description: ''
       type: object
@@ -1002,7 +1002,7 @@ components:
           type: string
         source_wallet_name:
           type: string
-          description: 'it is a pretty common use case that we need to display the wallet name in the frontend, so we''d better join and return the name of wallet'
+          description: "it is a pretty common use case that we need to display the wallet name in the frontend, so we'd better join and return the name of wallet"
         destination_wallet_name:
           type: string
         processed_at:
@@ -1053,7 +1053,7 @@ components:
           id: 0248f77a-1531-11ec-82a8-0242ac130003
           name: 180Earth
           token_in_wallet: 22
-          photo_url: '''https://180.earth/wp-content/uploads/2020/01/Asset-1.png'
+          photo_url: "'https://180.earth/wp-content/uploads/2020/01/Asset-1.png"
       properties:
         id:
           type: string

--- a/src/DesignSandbox.cy.js
+++ b/src/DesignSandbox.cy.js
@@ -1,11 +1,11 @@
 import React from 'react';
 
-import { mountWithTheme as mount } from './models/test-utils';
 import DesignSandbox from './DesignSandbox';
+import { mountWithTheme as mount } from './models/test-utils';
 
 describe('designSandbox', () => {
   it('it shows designSandbox', () => {
-    cy.viewport(867, 750);
+    cy.viewport(950, 750);
     mount(<DesignSandbox />);
   });
 });

--- a/src/DesignSandbox.js
+++ b/src/DesignSandbox.js
@@ -1,15 +1,15 @@
-import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
-import * as React from 'react';
-import { styled , useTheme } from '@mui/material/styles';
+import Paper from '@mui/material/Paper';
+import { styled, useTheme } from '@mui/material/styles';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell, { tableCellClasses } from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import * as React from 'react';
 
 const StyledTableCell = styled(TableCell)(({ theme }) => ({
   [`&.${tableCellClasses.head}`]: {
@@ -41,23 +41,23 @@ const colorData = [
 ];
 
 const Row = ({ color, isBackground }) => (
-    <StyledTableRow>
-      <TableCell component="th" scope="row">
-        <Typography variant="h6">{color}</Typography>
-      </TableCell>
-      <TableCell align="right">
-        <Box
-          sx={{
-            height: 50,
-            width: 50,
-            borderRadius: '50%',
-            bgcolor: isBackground || `${color}.main`,
-            background: (theme) => theme.palette.background[color],
-          }}
-        ></Box>
-      </TableCell>
-    </StyledTableRow>
-  );
+  <StyledTableRow>
+    <TableCell component="th" scope="row">
+      <Typography variant="h6">{color}</Typography>
+    </TableCell>
+    <TableCell align="right">
+      <Box
+        sx={{
+          height: 50,
+          width: 50,
+          borderRadius: '50%',
+          bgcolor: isBackground || `${color}.main`,
+          background: (theme) => theme.palette.background[color],
+        }}
+      ></Box>
+    </TableCell>
+  </StyledTableRow>
+);
 
 const DesignSandbox = () => {
   const theme = useTheme();

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -38,24 +38,9 @@ const useStyles = makeStyles()((theme) => ({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  welcome: {
-    [theme.breakpoints.down('sm')]: {
-      fontSize: '0.8rem',
-    },
-  },
-  slogan: {
-    [theme.breakpoints.down('sm')]: {
-      fontSize: '1.9rem',
-      lineHeight: '2.5rem',
-    },
-  },
   button: {
     textTransform: 'none',
     marginRight: 20,
-  },
-  findATreeButton: {
-    textTransform: 'none',
-    background: theme.palette.secondary.main,
   },
 }));
 
@@ -63,13 +48,19 @@ export default function Home() {
   const { classes } = useStyles();
 
   const Buttons = () => (
-    <Box className={classes.buttonsContainer}>
+    <Box className={classes.buttonsContainer} mt={4.5}>
       <Button variant="outlined" color="inherit" className={classes.button}>
-        Learn more
+        <Typography>Learn more</Typography>
       </Button>
       <Link href="/top">
-        <Button variant="contained" className={classes.findATreeButton}>
-          Let&apos;s Find a Tree
+        <Button
+          variant="contained"
+          color="secondary"
+          className={classes.button}
+        >
+          <Typography sx={{ color: 'textPrimary.main' }}>
+            Let&apos;s Find a Tree
+          </Typography>
         </Button>
       </Link>
     </Box>
@@ -78,10 +69,8 @@ export default function Home() {
   return (
     <Box className={classes.pageContainer}>
       <Box className={classes.contentContainer}>
-        <Typography variant="h3" className={classes.welcome}>
-          Welcome to TreeTracker
-        </Typography>
-        <Typography variant="h1" className={classes.slogan}>
+        <Typography variant="h3">Welcome to TreeTracker</Typography>
+        <Typography variant="h1">
           Come explore the global reforestation effort.
         </Typography>
         <Buttons />

--- a/src/components/InformationCard1.js
+++ b/src/components/InformationCard1.js
@@ -10,6 +10,9 @@ const useStyles = makeStyles()((theme) => ({
     background: theme.palette.background.greenOrangeLightGr,
     height: 'fit-content',
     padding: theme.spacing(6),
+    [theme.breakpoints.down('md')]: {
+      padding: theme.spacing(4),
+    },
     borderRadius: theme.spacing(4),
   },
   contentWrapper: {
@@ -34,17 +37,6 @@ const useStyles = makeStyles()((theme) => ({
     width: 110,
     borderRadius: '50%',
     float: 'left',
-  },
-  entityName: {
-    fontFamily: theme.typography.fontFamily,
-    fontWeight: 700,
-    fontSize: '1.75rem',
-    color: theme.palette.textPrimary.main,
-  },
-  entityType: {
-    fontFamily: theme.typography.fontFamily,
-    fontSize: '1rem',
-    color: theme.palette.textPrimary.main,
   },
 }));
 
@@ -77,8 +69,13 @@ function InformationCard1({
           flexDirection="column"
           justifyContent="center"
         >
-          <div className={classes.entityType}>{entityType}</div>
-          <div className={classes.entityName}>{entityName}</div>
+          <Typography>{entityType}</Typography>
+          <Typography
+            variant="h4"
+            sx={{ fontFamily: ['Lato'], letterSpacing: '0.02em' }}
+          >
+            {entityName}
+          </Typography>
         </Box>
       </div>
       <Link href={link}>

--- a/src/components/PageWrapper.js
+++ b/src/components/PageWrapper.js
@@ -1,8 +1,8 @@
 import { Box } from '@mui/material';
 import clsx from 'clsx';
 import { makeStyles } from 'models/makeStyles';
-import React from 'react';
 import { useRouter } from 'next/router';
+import React from 'react';
 
 import BackButton from './BackButton';
 import SearchButton from './SearchButton';

--- a/src/components/TreeSpeciesCard.js
+++ b/src/components/TreeSpeciesCard.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import Card from '@mui/material/Card';
 import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
 import Typography from '@mui/material/Typography';
 import { makeStyles } from 'models/makeStyles';
+import React from 'react';
 
 const useStyles = makeStyles()((theme) => ({
   root: {

--- a/src/components/VerifiedBadge.js
+++ b/src/components/VerifiedBadge.js
@@ -1,6 +1,6 @@
-import React from 'react';
 import CheckIcon from '@mui/icons-material/Check';
 import { Chip } from '@mui/material';
+import React from 'react';
 
 function VerifiedBadge({ verified, badgeName }) {
   return (
@@ -10,6 +10,7 @@ function VerifiedBadge({ verified, badgeName }) {
         bgcolor: verified ? 'primary.main' : 'textPrimary.main',
         color: 'common.white',
         borderRadius: 1,
+        fontSize: 12,
       }}
       size="small"
       icon={!verified ? null : <CheckIcon />}

--- a/src/components/common/CustomCard.js
+++ b/src/components/common/CustomCard.js
@@ -1,16 +1,15 @@
-import React from 'react';
 import Avatar from '@mui/material/Avatar';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
-import Typography from '@mui/material/Typography';
-
 import { useTheme } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+
 import { makeStyles } from '../../models/makeStyles';
 
 const useStyles = makeStyles()((theme) => ({
   root: {
-    minWidth: 275,
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
@@ -18,6 +17,33 @@ const useStyles = makeStyles()((theme) => ({
     marginTop: theme.spacing(6),
     marginBottom: theme.spacing(6),
     cursor: 'pointer',
+  },
+  avatar: {
+    height: 60,
+    width: 60,
+    background: theme.palette.common.white,
+    [theme.breakpoints.down('md')]: {
+      height: 36,
+      width: 36,
+    },
+    '& > svg': {
+      [theme.breakpoints.down('md')]: {
+        fontSize: '1.5rem',
+      },
+    },
+  },
+  cardContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    paddingLeft: 0,
+    [theme.breakpoints.down('md')]: {
+      padding: theme.spacing(2),
+    },
+    '&:last-child': {
+      [theme.breakpoints.down('md')]: {
+        paddingBottom: theme.spacing(2),
+      },
+    },
   },
 }));
 
@@ -37,26 +63,32 @@ const CustomCard = (props) => {
           : theme.palette.background.greenGradient,
       }}
     >
-      <CardMedia sx={{ padding: theme.spacing(4) }}>
+      <CardMedia
+        sx={{ padding: { xs: theme.spacing(2), md: theme.spacing(4) } }}
+      >
         <Avatar
+          className={classes.avatar}
           sx={{
-            height: 60,
-            width: 60,
             boxShadow: disabled ? '' : '0px 6px 12px 0px #585B5D40',
-            backgroundColor: 'white',
-            color: disabled ? 'textSecondary.main' : 'secondary.main',
+            color: disabled
+              ? theme.palette.textSecondary.main
+              : theme.palette.success.main,
           }}
         >
           {icon}
         </Avatar>
       </CardMedia>
-      <CardContent
-        sx={{ display: 'flex', flexDirection: 'column', paddingLeft: 0 }}
-      >
-        <Typography variant="body1" color="textSecondary">
+      <CardContent className={classes.cardContent}>
+        <Typography
+          variant="body1"
+          color="textSecondary"
+          sx={{ fontSize: { xs: 12, md: 16 } }}
+        >
           {title}
         </Typography>
-        <Typography variant="h2">{text}</Typography>
+        <Typography variant="h2" sx={{ fontSize: { xs: 16, sm: 24, md: 36 } }}>
+          {text}
+        </Typography>
       </CardContent>
     </Card>
   );

--- a/src/components/common/Filter.js
+++ b/src/components/common/Filter.js
@@ -1,12 +1,12 @@
 import FilterListRoundedIcon from '@mui/icons-material/FilterListRounded';
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
 import Button from '@mui/material/Button';
+import Grid from '@mui/material/Grid';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
+import log from 'loglevel';
 import { makeStyles } from 'models/makeStyles';
 import React from 'react';
-import log from 'loglevel';
 
 const useStyles = makeStyles()((theme) => ({
   title: {
@@ -92,7 +92,7 @@ function Filter(props) {
         </Box>
 
         <Box className={classes.container}>
-          {/*<Box className={`${classes.row}`}>
+          {/* <Box className={`${classes.row}`}>
           <TextField
             select
             label="Tree Species"

--- a/src/components/common/TreeTag.js
+++ b/src/components/common/TreeTag.js
@@ -10,6 +10,9 @@ const useStyles = makeStyles()((theme) => ({
     justifyContent: 'center',
     alignItems: 'center',
     padding: theme.spacing(4),
+    [theme.breakpoints.down('sm')]: {
+      padding: theme.spacing(2),
+    },
     color: theme.palette.common.white,
     background: theme.palette.primary.main,
     borderRadius: theme.spacing(4),
@@ -23,11 +26,16 @@ function TreeTagComponent({ TreeTagValue, title, icon }) {
   const { classes } = useStyles();
   return (
     <Grid container className={classes.container}>
-      <Grid item sx={{ pr: 4 }}>
+      <Grid item sx={{ pr: { xs: 2, md: 4 } }}>
         {icon}
       </Grid>
       <Grid item>
-        <Typography variant="body1">{title}</Typography>
+        <Typography
+          variant="body1"
+          sx={{ fontSize: { xs: '12px', md: '16px' } }}
+        >
+          {title}
+        </Typography>
         <Typography variant="h5">{TreeTagValue}</Typography>
       </Grid>
     </Grid>

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -1,16 +1,18 @@
+import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined';
+import ParkOutlinedIcon from '@mui/icons-material/ParkOutlined';
+import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
-//import Card from '@mui/material/Card';
+// import Card from '@mui/material/Card';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid';
-import Avatar from '@mui/material/Avatar';
-import { makeStyles } from '../../models/makeStyles';
 import Typography from '@mui/material/Typography';
+import TreeSpeciesCard from 'components/TreeSpeciesCard';
 import log from 'loglevel';
-//import Image from 'next/image';
+import moment from 'moment';
+// import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import ParkOutlinedIcon from '@mui/icons-material/ParkOutlined';
-import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined';
 
+import CustomCard from '../../components/common/CustomCard';
 import Location from '../../components/common/Location';
 import Time from '../../components/common/Time';
 import FeaturedTreesSlider from '../../components/FeaturedTreesSlider';
@@ -18,10 +20,8 @@ import InformationCard1 from '../../components/InformationCard1';
 import PageWrapper from '../../components/PageWrapper';
 import VerifiedBadge from '../../components/VerifiedBadge';
 import { useMapContext } from '../../mapContext';
+import { makeStyles } from '../../models/makeStyles';
 import * as utils from '../../models/utils';
-import moment from 'moment';
-import TreeSpeciesCard from 'components/TreeSpeciesCard';
-import CustomCard from '../../components/common/CustomCard';
 
 // make styles for component with material-ui
 const useStyles = makeStyles()((theme) => ({
@@ -46,6 +46,9 @@ const useStyles = makeStyles()((theme) => ({
     marginLeft: theme.spacing(-10),
     marginRight: theme.spacing(-10),
     width: '100%',
+  },
+  textColor: {
+    color: theme.palette.textPrimary.main,
   },
 }));
 
@@ -80,7 +83,7 @@ export default function Planter({ planter }) {
 
   return (
     <PageWrapper className={classes.root}>
-      <Typography variant="h2" sx={{ color: 'textPrimary.main' }}>
+      <Typography variant="h2" classname={classes.textColor}>
         {planter.first_name} {planter.last_name}
       </Typography>
       <Box sx={{ display: 'flex', gap: 2 }}>
@@ -109,26 +112,29 @@ export default function Planter({ planter }) {
         variant="rounded"
         sx={{ width: '100%', height: '688px', borderRadius: 6, marginTop: 6 }}
       />
-      <Grid container spacing={1}>
-        <Grid item>
+      <Grid
+        container
+        spacing={2}
+        wrap="nowrap"
+        justifyContent="center"
+        sx={{ width: '100%' }}
+      >
+        <Grid item sx={{ width: '50%' }}>
           <CustomCard
             handleClick={handleCardClick}
             icon={<ParkOutlinedIcon fontSize="large" />}
             title="Trees Planted"
             text={planter.featuredTrees.total}
-            disabled={isPlanterTab ? false : true}
+            disabled={!isPlanterTab}
           />
         </Grid>
-        <Grid item>
-          <Box width={8} />
-        </Grid>
-        <Grid item>
+        <Grid item sx={{ width: '50%' }}>
           <CustomCard
             handleClick={handleCardClick}
             icon={<GroupsOutlinedIcon fontSize="large" />}
-            title="Associated Organizations"
+            title="Ass. Orgs"
             text={planter.associatedOrganizations.total}
-            disabled={!isPlanterTab ? false : true}
+            disabled={!!isPlanterTab}
           />
         </Grid>
       </Grid>
@@ -172,20 +178,24 @@ export default function Planter({ planter }) {
       </Box>
       <Box mt={10} />
       <Divider className={classes.divider} />
-      <Box mt={20} />
-      <Typography variant="h4" sx={{ color: 'textPrimary.main' }}>
+      <Typography
+        variant="h4"
+        classname={classes.textColor}
+        sx={{ mt: { xs: 12, md: 20 } }}
+      >
         About
       </Typography>
-      <Box mt={7} />
-      <Typography variant="body1" sx={{ color: 'textPrimary.main' }}>
+      <Typography variant="body1" classname={classes.textColor} mt={7}>
         {planter.about}
       </Typography>
-      <Box mt={16} />
-      <Typography variant="h4" sx={{ color: 'textPrimary.main' }}>
+      <Typography
+        variant="h4"
+        classname={classes.textColor}
+        sx={{ mt: { xs: 10, md: 16 } }}
+      >
         Mission
       </Typography>
-      <Box mt={7} />
-      <Typography variant="body1" sx={{ color: 'textPrimary.main' }}>
+      <Typography variant="body1" classname={classes.textColor} mt={7}>
         {planter.mission}
       </Typography>
       <Box mt={20} />

--- a/src/pages/top.js
+++ b/src/pages/top.js
@@ -1,12 +1,12 @@
-import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
 import log from 'loglevel';
 import { makeStyles } from 'models/makeStyles';
 import React from 'react';
 
+import Filter from '../components/common/Filter';
 import FeaturedTreesSlider from '../components/FeaturedTreesSlider';
 import LeaderBoard from '../components/LeaderBoard';
-import Filter from '../components/common/Filter';
 import { useMapContext } from '../mapContext';
 import * as utils from '../models/utils';
 
@@ -14,8 +14,8 @@ import * as utils from '../models/utils';
 const useStyles = makeStyles()((theme) => ({
   root: {
     padding: theme.spacing(3, 4),
-    maxWidth: "100%",
-    boxSizing: "border-box",
+    maxWidth: '100%',
+    boxSizing: 'border-box',
   },
   title: {
     fontFamily: 'Montserrat',
@@ -69,7 +69,7 @@ export default function Top({ trees, countries }) {
 
   return (
     <div className={classes.root}>
-      <Box sx={{display: "flex", justifyContent: "flex-end", }}>
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
         <Filter onFilter={handleFilter} />
       </Box>
       <Typography variant="h2" className={classes.title}>

--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -41,17 +41,11 @@ const useStyles = makeStyles()((theme) => ({
     marginTop: theme.spacing(10),
     width: '100%',
   },
-  title2: {
-    marginTop: theme.spacing(26),
-    fontSize: '28px',
-    lineHeight: '34px',
-    display: 'flex',
-    alignItems: 'center',
-    textAlign: 'center',
-    color: '#585B5D',
-  },
   tabBox: {
     marginTop: theme.spacing(9),
+    [theme.breakpoints.down('md')]: {
+      marginTop: theme.spacing(5),
+    },
     flexWrap: 'wrap',
     display: 'flex',
     '& div': {
@@ -131,7 +125,10 @@ export default function Tree({ tree, planter, organization }) {
           link={`/planters/${planter.id}`}
         />
       </Box>
-      <Typography variant="h4" className={classes.title2}>
+      <Typography
+        variant="h4"
+        sx={{ color: 'textPrimary.main', mt: { xs: 14, md: 26 } }}
+      >
         Tree Info
       </Typography>
       <Box className={classes.tabBox}>

--- a/src/theme.js
+++ b/src/theme.js
@@ -3,48 +3,8 @@
  */
 import { createTheme } from '@mui/material/styles';
 
-const theme = createTheme({
+const colorTheme = createTheme({
   spacing: 4,
-  typography: {
-    fontFamily: ['Lato', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'].join(
-      ',',
-    ),
-    fontWeight: 400,
-    h1: {
-      fontFamily: ['Montserrat'].join(','),
-      fontSize: '48px',
-      fontWeight: 600,
-      lineHeight: '63px',
-    },
-    h2: {
-      fontFamily: 'Montserrat',
-      fontSize: '36px',
-      lineHeight: '44px',
-      fontWeight: 600,
-    },
-    h3: {
-      fontFamily: 'Montserrat',
-      fontSize: '32px',
-      lineHeight: '28px',
-      fontWeight: 600,
-    },
-    h4: {
-      fontFamily: 'Montserrat',
-      fontSize: '28px',
-      fontWeight: 700,
-    },
-    h5: {
-      fontSize: '20px',
-      fontWeight: 700,
-    },
-    h6: {
-      fontSize: '16px',
-      fontWeight: 700,
-    },
-    body1: {
-      letterSpacing: '0.04em',
-    },
-  },
   palette: {
     background: {
       greenGradient:
@@ -63,6 +23,7 @@ const theme = createTheme({
     },
     secondary: {
       main: '#86C232',
+      contrastText: '#fff',
     },
     textPrimary: {
       main: '#474B4F',
@@ -75,6 +36,69 @@ const theme = createTheme({
     },
     textLight: {
       main: '#6B6E70',
+    },
+  },
+});
+
+const theme = createTheme(colorTheme, {
+  typography: {
+    fontFamily: ['Lato', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'].join(
+      ',',
+    ),
+    fontWeight: 400,
+    h1: {
+      fontFamily: ['Montserrat'].join(','),
+      fontSize: '48px',
+      fontWeight: 600,
+      lineHeight: '63px',
+      [colorTheme.breakpoints.down('md')]: {
+        lineHeight: '32px',
+        fontSize: '32px',
+      },
+    },
+    h2: {
+      fontFamily: 'Montserrat',
+      fontSize: '36px',
+      lineHeight: '44px',
+      fontWeight: 600,
+      [colorTheme.breakpoints.down('md')]: {
+        lineHeight: '30px',
+        fontSize: '24px',
+      },
+    },
+    h3: {
+      fontFamily: 'Montserrat',
+      fontSize: '32px',
+      lineHeight: '28px',
+      fontWeight: 600,
+      [colorTheme.breakpoints.down('md')]: {
+        fontSize: '16px',
+      },
+    },
+    h4: {
+      fontFamily: 'Montserrat',
+      fontSize: '28px',
+      fontWeight: 700,
+      [colorTheme.breakpoints.down('md')]: {
+        fontSize: '20px',
+      },
+    },
+    h5: {
+      fontSize: '20px',
+      fontWeight: 700,
+      [colorTheme.breakpoints.down('md')]: {
+        fontSize: '16px',
+      },
+    },
+    h6: {
+      fontSize: '16px',
+      fontWeight: 700,
+    },
+    body1: {
+      letterSpacing: '0.04em',
+      [colorTheme.breakpoints.down('md')]: {
+        fontSize: '14px',
+      },
     },
   },
 });


### PR DESCRIPTION
# Description

Font sizes are responsive on their own now (check the design first though, you might find some differences from the main style from time to time).
Padding and margins are not, they have to be done manually. Did this on the planter and tree page.

![Screenshot from 2021-12-13 11-22-55](https://user-images.githubusercontent.com/31432331/145798203-45261a57-dc75-4966-be52-d752dddcba55.png)![Screenshot from 2021-12-13 11-23-09](https://user-images.githubusercontent.com/31432331/145798214-bc755937-2603-4a66-bb97-6a2135e54edb.png)
![Screenshot from 2021-12-13 11-23-13](https://user-images.githubusercontent.com/31432331/145798227-a4efa7fc-4e5b-4337-9c31-349a83bf2515.png)



Fixes #344

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Cypress component tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

