### PR TITLE
fix: lint-staged settings

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -3,8 +3,8 @@ module.exports = {
   '*': ['prettier --ignore-unknown --write'],
 
   // lint javascript after formatting
-  '*.{js,jsx}': ['eslint --fix --cache --quiet'],
+  '*.{js,jsx}': ['eslint --fix'],
 
-  // lint entire project if eslint settings changed
-  '.eslint*': ['eslint . --cache'],
+  // lint entire project if eslint settings changed, do not pass file name arguments
+  '.eslint*': () => 'eslint .',
 };


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

The current lint-staged settings were letting some fixable warnings pass by, possibly because of the `--cache` setting. Because lint-staged passes file name arguments the --cache setting is not needing. Also the lint-staged command to lint the entire project has been rewritten to [no longer pass the filename arguments](https://github.com/okonet/lint-staged#example-run-tsc-on-changes-to-typescript-files-but-do-not-pass-any-filename-arguments). This function also does not need the cache setting if the intention is to always lint the entire project. 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

