### PR TITLE
feat: modify FeaturedTreesSlider to support display of small sized im…

### DIFF
--- a/src/components/FeaturedTreesSlider/index.js
+++ b/src/components/FeaturedTreesSlider/index.js
@@ -6,11 +6,11 @@ import React, { useRef } from 'react';
 import Link from '../Link';
 import { useStyles } from './style'; // the style file
 
-function FeaturedTreesSlider(props) {
-  const { classes } = useStyles();
+function FeaturedTreesSlider({ trees, size = null }) {
+  // default size of images = 208px;
+  // if size="small" props is passed in, size of images= 144px
+  const { classes } = useStyles(size);
   const sliderRef = useRef();
-
-  const { trees } = props;
 
   const scrollHandler = (num) => {
     sliderRef.current.scrollLeft += num;

--- a/src/components/FeaturedTreesSlider/style.js
+++ b/src/components/FeaturedTreesSlider/style.js
@@ -1,6 +1,6 @@
 import { makeStyles } from 'models/makeStyles';
 
-const useStyles = makeStyles()((theme) => ({
+const useStyles = makeStyles()((theme, size) => ({
   SliderContainer: {
     position: 'relative',
     width: '100%',
@@ -13,13 +13,14 @@ const useStyles = makeStyles()((theme) => ({
   },
   SliderImgContainer: {
     display: 'flex',
-    gap: '8px',
+    gap: theme.spacing(3),
     position: 'relative',
     overflowX: 'scroll',
     scrollBehavior: 'smooth',
     scrollSnapType: 'x mandatory',
     padding: '2rem 0',
     scrollPadding: '0 50%',
+    scrollbarWidth: 'none',
     '&::-webkit-scrollbar': {
       display: 'none',
     },
@@ -37,9 +38,9 @@ const useStyles = makeStyles()((theme) => ({
     transition: 'transform .5s',
     width: '100%',
     height: '100%',
-    minWidth: '208px',
+    minWidth: size === 'small' ? '144px' : '208px',
     [theme.breakpoints.down('sm')]: {
-      minWidth: '152px',
+      minWidth: size === 'small' ? '144px' : '152px',
     },
   },
   GoRight: {
@@ -98,8 +99,8 @@ const useStyles = makeStyles()((theme) => ({
     transition: 'all .5s',
   },
   Card: {
-    width: '208px',
-    height: '208px',
+    width: size === 'small' ? '144px' : '208px',
+    height: size === 'small' ? '144px' : '208px',
     transition: 'all .5s',
     scrollSnapAlign: 'center',
     scrollBehavior: 'smooth',
@@ -112,8 +113,8 @@ const useStyles = makeStyles()((theme) => ({
       },
     },
     [theme.breakpoints.down('sm')]: {
-      width: '152px',
-      height: '152px',
+      width: size === 'small' ? '144px' : '152px',
+      height: size === 'small' ? '144px' : '152px',
     },
   },
 }));


### PR DESCRIPTION
…ages

# Description

FeaturedTreesSlider can now take in size="small" props and display smaller sized images. If size is not passed in, the original (default) size of images will be displayed.

Fixes #308

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)

## Screenshots 

[comment]: # 'Please include screenshots of your changes if relevant.'
`<FeaturedTreesSlider trees={trees} size="small"/>`
![small](https://user-images.githubusercontent.com/52301822/148295755-4033ad55-5a64-452e-a56f-57e2252b6021.png)

[Default]
`<FeaturedTreesSlider trees={trees}/>`
![default](https://user-images.githubusercontent.com/52301822/148295763-13b00614-15d4-42d4-8179-979afac15b6e.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

