### PR TITLE
style: issue #409 css problem align custom cards

### DIFF
--- a/src/components/common/CustomCard.js
+++ b/src/components/common/CustomCard.js
@@ -69,7 +69,7 @@ function CustomCard(props) {
           sx={{
             boxShadow: disabled ? '' : '0px 6px 12px 0px #585B5D40',
             color: disabled
-              ? theme.palette.textSecondary.main
+              ? theme.palette.textLight.main
               : theme.palette.success.main,
           }}
         >

--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -1,7 +1,7 @@
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
-import GroupsOutlinedIcon from '@mui/icons-material/GroupsOutlined';
 import LocationOnIcon from '@mui/icons-material/LocationOn';
 import ParkOutlinedIcon from '@mui/icons-material/ParkOutlined';
+import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import { Box, Divider, Grid, Typography } from '@mui/material';
 import log from 'loglevel';
 import React from 'react';
@@ -145,7 +145,33 @@ export default function Organization({ organization }) {
           <img src={logo_url} />
         </Box>
       </Box>
-      <Grid container spacing={1}>
+      <Grid
+        container
+        wrap="nowrap"
+        justifyContent="space-between"
+        sx={{ width: '100%' }}
+      >
+        <Grid item sx={{ width: '49%' }}>
+          <CustomCard
+            handleClick={handleCardClick}
+            icon={<ParkOutlinedIcon fontSize="large" />}
+            title="Trees Planted"
+            text={organization?.featuredTrees?.total}
+            disabled={isPlanterTab}
+          />
+        </Grid>
+        <Grid item sx={{ width: '49%' }}>
+          <CustomCard
+            handleClick={handleCardClick}
+            icon={<PersonOutlineIcon fontSize="large" />}
+            title="Hired Planters"
+            text={organization?.associatedPlanters?.total}
+            disabled={!isPlanterTab}
+          />
+        </Grid>
+      </Grid>
+
+      {/* <Grid container spacing={1}>
         <Grid item>
           <CustomCard
             handleClick={handleCardClick}
@@ -167,7 +193,7 @@ export default function Organization({ organization }) {
             disabled={!isPlanterTab}
           />
         </Grid>
-      </Grid>
+      </Grid> */}
       {!isPlanterTab && (
         <Box>
           <CustomWorldMap totalTrees={organization?.featuredTrees?.total} />

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -120,12 +120,11 @@ export default function Planter({ planter }) {
       />
       <Grid
         container
-        spacing={2}
         wrap="nowrap"
-        justifyContent="center"
+        justifyContent="space-between"
         sx={{ width: '100%' }}
       >
-        <Grid item sx={{ width: '50%' }}>
+        <Grid item sx={{ width: '49%' }}>
           <CustomCard
             handleClick={handleCardClick}
             icon={<ParkOutlinedIcon fontSize="large" />}
@@ -134,7 +133,7 @@ export default function Planter({ planter }) {
             disabled={!isPlanterTab}
           />
         </Grid>
-        <Grid item sx={{ width: '50%' }}>
+        <Grid item sx={{ width: '49%' }}>
           <CustomCard
             handleClick={handleCardClick}
             icon={<GroupsOutlinedIcon fontSize="large" />}


### PR DESCRIPTION
# Description

Aligned the custom cards properly to be centered and the same width on all screens. Fixed it on the planter page, there was also some misalignment.

Sidenote: "Associated Organizations" is a long title for the card. So I shortened it to "Ass. orgs.". It feels a bit of a "hacky" solution, but the long word will mess up the style of the card one way or another. So I'm fine with it.

Fixes #409

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
![Screenshot from 2022-01-14 10-39-15](https://user-images.githubusercontent.com/31432331/149493916-a6573d8f-b92c-4388-9e3a-9b6140c8f3e7.png)


[comment]: # 'Please include screenshots of your changes if relevant.'

# How Has This Been Tested?

- [x] Cypress component tests

# Checklist:

- [x] I have performed a self-review of my own code
