### PR TITLE
feat: issue #417 default bg image

### DIFF
--- a/src/components/InformationCard1.js
+++ b/src/components/InformationCard1.js
@@ -2,6 +2,7 @@ import { Box, Button, CardMedia, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'models/makeStyles';
 import Link from './Link';
+import Logo from '../images/greenstand_logo.svg';
 
 const useStyles = makeStyles()((theme) => ({
   container: {
@@ -64,9 +65,8 @@ function InformationCard1({
       <div>
         <CardMedia
           className={classes.media}
-          image={cardImageSrc}
+          image={cardImageSrc || Logo}
           title="Contemplative Reptile"
-          src={classes.media}
         />
         <Box
           className={classes.contentWrapper}


### PR DESCRIPTION
# Description

Add default bg image for informationCard component.

Fixes #417

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
![Screenshot from 2022-01-15 10-24-02](https://user-images.githubusercontent.com/31432331/149616926-46535671-37c1-43f5-9fa1-a0757ca8234f.png)

___

There is another solution I came up with:
![Screenshot from 2022-01-15 10-14-12](https://user-images.githubusercontent.com/31432331/149617007-90d941f3-7e68-4674-8bcf-acd7d6defda9.png)

Personally prefer the first one, fits better with the design IMO. That's the solution I went with in this PR. Let me know what you think.

# How Has This Been Tested?

- [x] Cypress component tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
