### PR TITLE
style: switch to green icon suite

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -153,9 +153,10 @@ function MapComponent() {
       onFindNearestAt: handleFindNearestAt,
       onError: handleError,
       filters: parameters,
-      tileServerUrl: process.env.NEXT_PUBLIC_TILE_SERVER_URL,
-      tileServerSubdomains:
-        process.env.NEXT_PUBLIC_TILE_SERVER_SUBDOMAINS.split(','),
+      iconSuite: 'green',
+      // tileServerUrl: process.env.NEXT_PUBLIC_TILE_SERVER_URL,
+      // tileServerSubdomains:
+      //   process.env.NEXT_PUBLIC_TILE_SERVER_SUBDOMAINS.split(','),
     });
     map.on('moveEnd', () => {
       log.warn('update url');


### PR DESCRIPTION
# Add iconSuite to map options, and set it to 'green'

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

- Added iconSuite to map options and set it to 'green'
- Removed tileServerUrl and tileServerSubdomain because it will be set by map-core based on iconSuite setting

