### PR TITLE
feat: issue #426 hide full name

### DIFF
--- a/src/models/utils.js
+++ b/src/models/utils.js
@@ -74,10 +74,14 @@ function formatDateString(date) {
   return new Date(date).toLocaleDateString('en-GB');
 }
 
+// Hide full name, show only first char and a dot
+const hideFullName = (name) => `${name.charAt(0)}.`;
+
 export {
   parseDomain,
   parseMapName,
   requestAPI,
   getContinent,
   formatDateString,
+  hideFullName,
 };

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -87,7 +87,7 @@ export default function Planter({ planter }) {
   return (
     <PageWrapper>
       <Typography variant="h2" className={classes.textColor}>
-        {planter.first_name} {planter.last_name}
+        {planter.first_name} {utils.hideFullName(planter.last_name)}
       </Typography>
       <Box sx={{ display: 'flex', gap: 2 }}>
         <VerifiedBadge verified badgeName="Verified Planter" />


### PR DESCRIPTION
# Description

Created a function that hides the planter's full name. Returns the first letter of the name and a dot at the end.

Fixes #426
## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots
![Screenshot from 2022-01-29 11-52-26](https://user-images.githubusercontent.com/31432331/151658365-e8beb3e8-0c6c-4558-910a-e45f2eaa35fb.png)
