### PR TITLE
style: issue #442 refine trees page

### DIFF
--- a/src/components/BackButton.js
+++ b/src/components/BackButton.js
@@ -6,7 +6,9 @@ export default function BackButton({ onBackHandler }) {
   return (
     <ButtonBase onClick={onBackHandler} sx={{ color: 'textLight.main' }}>
       <ArrowBackIosIcon fontSize="inherit" />
-      <Typography>Back</Typography>
+      <Typography variant="body1" sx={{ lineHeight: '16px' }}>
+        Back
+      </Typography>
     </ButtonBase>
   );
 }

--- a/src/components/InformationCard1.js
+++ b/src/components/InformationCard1.js
@@ -34,6 +34,10 @@ const useStyles = makeStyles()((theme) => ({
   media: {
     height: 110,
     width: 110,
+    [theme.breakpoints.down('md')]: {
+      height: 80,
+      width: 80,
+    },
     borderRadius: '50%',
     float: 'left',
   },
@@ -62,7 +66,7 @@ function InformationCard1({
             : theme.palette.background.greenOrangeLightGrInverse,
       }}
     >
-      <div>
+      <Box display="flex" alignItems="center">
         <CardMedia
           className={classes.media}
           image={cardImageSrc || Logo}
@@ -75,18 +79,30 @@ function InformationCard1({
           flexDirection="column"
           justifyContent="center"
         >
-          <Typography>{entityType}</Typography>
+          <Typography variant="body1">{entityType}</Typography>
           <Typography
             variant="h4"
-            sx={{ fontFamily: ['Lato'], letterSpacing: '0.02em' }}
+            sx={{
+              fontFamily: 'Lato',
+              fontWeight: 700,
+              letterSpacing: '0.02em',
+            }}
           >
             {entityName}
           </Typography>
         </Box>
-      </div>
+      </Box>
       <Link href={link}>
         <Button className={classes.button} fullWidth>
-          <Typography variant="h5">{buttonText}</Typography>
+          <Typography
+            variant="h5"
+            sx={{
+              color: 'textSecondary.main',
+              fontFamily: 'Lato',
+            }}
+          >
+            {buttonText}
+          </Typography>
         </Button>
       </Link>
     </Box>

--- a/src/components/VerifiedBadge.js
+++ b/src/components/VerifiedBadge.js
@@ -1,15 +1,28 @@
 import CheckIcon from '@mui/icons-material/Check';
 import { Chip } from '@mui/material';
+import { makeStyles } from 'models/makeStyles';
+
+const useStyles = makeStyles()(() => ({
+  root: {
+    '&.Mui-disabled': {
+      opacity: 1,
+    },
+  },
+}));
 
 function VerifiedBadge({ verified, badgeName }) {
+  const { classes } = useStyles();
   return (
     <Chip
       color="primary"
+      className={classes.root}
       sx={{
-        bgcolor: verified ? 'primary.main' : 'textPrimary.main',
+        bgcolor: verified ? 'primary.main' : 'textLight.main',
         color: 'common.white',
         borderRadius: 1,
         fontSize: 12,
+        lineHeight: '16px',
+        letterSpacing: '0.02em',
       }}
       size="small"
       icon={!verified ? null : <CheckIcon />}

--- a/src/components/common/CustomImageWrapper.js
+++ b/src/components/common/CustomImageWrapper.js
@@ -33,7 +33,8 @@ function InfoWrapper({ children, top, right, bottom }) {
     <Box
       ml={3}
       mr={2}
-      p={4}
+      py={4}
+      px={5}
       sx={{
         bgcolor: 'textPrimary.main',
         opacity: 0.8,

--- a/src/components/common/TreeTag.js
+++ b/src/components/common/TreeTag.js
@@ -8,9 +8,9 @@ const useStyles = makeStyles()((theme) => ({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    padding: theme.spacing(4),
+    padding: theme.spacing(4.875, 6),
     [theme.breakpoints.down('sm')]: {
-      padding: theme.spacing(2),
+      padding: theme.spacing(3.375, 3.875),
     },
     color: theme.palette.common.white,
     background: theme.palette.primary.main,
@@ -25,17 +25,14 @@ function TreeTagComponent({ TreeTagValue, title, icon }) {
   const { classes } = useStyles();
   return (
     <Grid container className={classes.container}>
-      <Grid item sx={{ pr: { xs: 2, md: 4 } }}>
+      <Grid item sx={{ pr: [2, 4] }}>
         {icon}
       </Grid>
       <Grid item>
-        <Typography
-          variant="body1"
-          sx={{ fontSize: { xs: '12px', md: '16px' } }}
-        >
-          {title}
+        <Typography variant="body1">{title}</Typography>
+        <Typography variant="h5" sx={{ fontFamily: 'Lato' }}>
+          {TreeTagValue}
         </Typography>
-        <Typography variant="h5">{TreeTagValue}</Typography>
       </Grid>
     </Grid>
   );

--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -48,7 +48,10 @@ const useStyles = makeStyles()((theme) => ({
     flexWrap: 'wrap',
     display: 'flex',
     '& div': {
-      margin: theme.spacing(1),
+      margin: theme.spacing(2),
+      [theme.breakpoints.down('md')]: {
+        marginTop: theme.spacing(1),
+      },
     },
   },
 }));
@@ -73,7 +76,7 @@ export default function Tree({ tree, planter, organization }) {
         Tree{/* tree.species */} - #{tree.id}
       </Typography>
       <Typography
-        sx={{ color: 'textPrimary.main', fontWeight: 300 }}
+        sx={{ color: 'textPrimary.main', fontWeight: 400 }}
         variant="h5"
       >
         Eco-Peace-Vision
@@ -109,7 +112,12 @@ export default function Tree({ tree, planter, organization }) {
       </Box>
       <Typography
         variant="h4"
-        sx={{ color: 'textPrimary.main', mt: { xs: 14, md: 26 } }}
+        sx={{
+          color: 'textPrimary.main',
+          fontSize: [24, 28],
+          lineHeight: ['29.26px', '34.13px'],
+          mt: (t) => [t.spacing(14), t.spacing(26)],
+        }}
       >
         Tree Info
       </Typography>

--- a/src/theme.js
+++ b/src/theme.js
@@ -60,9 +60,10 @@ const theme = createTheme(colorTheme, {
       fontFamily: 'Montserrat',
       fontSize: '36px',
       lineHeight: '44px',
-      fontWeight: 600,
+      fontWeight: 700,
+      letterSpacing: 0,
       [colorTheme.breakpoints.down('md')]: {
-        lineHeight: '30px',
+        lineHeight: '29.26px',
         fontSize: '24px',
       },
     },
@@ -78,27 +79,47 @@ const theme = createTheme(colorTheme, {
     h4: {
       fontFamily: 'Montserrat',
       fontSize: '28px',
-      fontWeight: 700,
+      fontWeight: 600,
+      lineHeight: '33.6px',
+      letterSpacing: 0,
       [colorTheme.breakpoints.down('md')]: {
         fontSize: '20px',
+        lineHeight: '24px',
       },
     },
     h5: {
+      fontFamily: 'Montserrat',
       fontSize: '20px',
       fontWeight: 700,
+      lineHeight: '24px',
+      letterSpacing: '0.02em',
       [colorTheme.breakpoints.down('md')]: {
         fontSize: '16px',
+        lineHeight: '19.5px',
       },
     },
     h6: {
+      fontFamily: 'Lato',
       fontSize: '16px',
       fontWeight: 700,
+      lineHeight: '19px',
+      letterSpacing: '0.02em',
     },
     body1: {
+      fontFamily: 'Lato',
+      fontSize: '16px',
+      lineHeight: '19.2px',
       letterSpacing: '0.04em',
       [colorTheme.breakpoints.down('md')]: {
-        fontSize: '14px',
+        fontSize: '12px',
+        lineHeight: '14.4px',
       },
+    },
+    caption: {
+      fontFamily: 'Lato',
+      fontSize: '12px',
+      lineHeight: '14.4px',
+      letterSpacing: '0.04em',
     },
   },
 });


### PR DESCRIPTION
# Description

Refined the trees page styling to get as close to the Figma design as possible. 
In some places, there are font weights 500 and 800 which are not valid for Lato. I used 400 and 700 instead.

Fixes #442

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots


![Screenshot from 2022-01-29 18-36-54](https://user-images.githubusercontent.com/31432331/151671309-1c730c54-5913-497e-884c-f242c3474b29.png)

![Screenshot from 2022-01-29 18-38-20](https://user-images.githubusercontent.com/31432331/151671340-b2e9bdb1-3e2f-4fa6-a27c-05215ec24b2b.png)




