### PR TITLE
feat: get and display country name from api (#446)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ yarn-error.log*
 .eslintcache
 .vscode
 .history
+.idea

--- a/cypress/tests/integration/planters/[planterid].cy.js
+++ b/cypress/tests/integration/planters/[planterid].cy.js
@@ -78,6 +78,8 @@ describe('Planter page', () => {
       failOnStatusCode: false,
     });
     cy.contains(planter.id);
-    cy.get('.MuiTypography-h2').contains(/sebastian gaertner/i);
+    cy.get('.MuiTypography-h2').contains(/sebastian g/i);
+    // NOTE: this would be the country assertion if the county mock would cooperate
+    // cy.get('.MuiTypography-body1').contains(planter.country);
   });
 });

--- a/src/components/common/Filter.cy.js
+++ b/src/components/common/Filter.cy.js
@@ -13,7 +13,7 @@ describe('Filter', () => {
 
     mount(<Filter onFilter={handleFilter} />);
     cy.contains(/Filters/i).click();
-    cy.contains(/timeline/i);
+    cy.contains(/Planted between/i);
 
     cy.contains('label', 'Start Date')
       .parent()
@@ -37,7 +37,7 @@ describe('Filter', () => {
 
     mount(<Filter onFilter={handleFilter} />);
     cy.contains(/Filters/i).click();
-    cy.contains(/timeline/i);
+    cy.contains(/Planted between/i);
     cy.contains('label', 'Start Date')
       .parent()
       .find('input')
@@ -55,7 +55,7 @@ describe('Filter', () => {
   it('Cancel Button hides the filters', () => {
     mount(<Filter />);
     cy.contains(/Filters/i).click();
-    cy.contains(/timeline/i);
+    cy.contains(/Planted between/i);
 
     cy.get('button').contains('Cancel').click();
 

--- a/src/models/utils.js
+++ b/src/models/utils.js
@@ -2,9 +2,11 @@ import log from 'loglevel';
 import moment from 'moment';
 
 function hideLastName(name) {
-  const fullNameArray = name.split(' ');
-  const hiddenFullName = `${fullNameArray[0]} ${fullNameArray[1][0]}`;
-  return hiddenFullName;
+  const fullNameArray = name?.split(' ');
+  if (fullNameArray?.length > 1) {
+    return `${fullNameArray[0]} ${fullNameArray[1][0]}`;
+  }
+  return name;
 }
 
 function parseDomain(url) {
@@ -87,14 +89,15 @@ const formatDates = (date, format) =>
 
 // Fix country names so it get return the correct alpha2 code for the flags
 // todo other faulty country names should be added later
-const fixCountryNames = (countries) => countries.map((country) => {
+const fixCountryNames = (countries) =>
+  countries.map((country) => {
     if (country.name === 'Tanzania') {
       return { ...country, name: 'Tanzania, United Republic of' };
-    } if (country.name === 'Democratic Republic of the Congo') {
+    }
+    if (country.name === 'Democratic Republic of the Congo') {
       return { ...country, name: 'Congo, the Democratic Republic of the' };
-    } 
-      return country;
-    
+    }
+    return country;
   });
 
 export {

--- a/src/models/utils.test.js
+++ b/src/models/utils.test.js
@@ -10,6 +10,9 @@ describe('hideLastName', () => {
   it('Dadior Chen should return Dadior C', () => {
     expect(hideLastName('Dadior Chen')).toBe('Dadior C');
   });
+  it('Scott should return Scott', () => {
+    expect(hideLastName('Scott')).toBe('Scott');
+  });
 });
 
 describe('parseMapName', () => {

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -272,11 +272,11 @@ export async function getServerSideProps({ params }) {
     if (props.planter.featuredTrees?.trees?.length) {
       const { lat, lon } = props.planter.featuredTrees.trees[0];
       if (lat && lon) {
-        const { countries } = await utils.requestAPI(
+        const countriesResponse = await utils.requestAPI(
           `/countries?lat=${lat}&lon=${lon}`,
         );
-        if (countries?.length) {
-          const [first] = countries;
+        if (countriesResponse?.countries?.length) {
+          const [first] = countriesResponse.countries;
           props.planter.country = first;
         }
       }

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -83,8 +83,10 @@ export default function Planter({ planter }) {
       </Typography>
 
       <Stack gap={{ xs: 1, sm: 2 }} sx={{ mb: 3, mt: [2, 3] }}>
-        <DataTag data={utils.formatDates(planter.created_time, 'LL')} />
-        <DataTag data="Shirimatunda, Tanzania" location />
+        {planter?.created_time && (
+          <DataTag data={utils.formatDates(planter.created_time, 'LL')} />
+        )}
+        {planter?.country && <DataTag data={planter?.country?.name} location />}
       </Stack>
       <Box sx={{ display: 'flex', gap: 2 }}>
         <VerifiedBadge verified badgeName="Verified Planter" />
@@ -267,6 +269,18 @@ export async function getServerSideProps({ params }) {
       associated_organizations,
     );
     props.planter.species = await utils.requestAPI(species);
+    if (props.planter.featuredTrees?.trees?.length) {
+      const { lat, lon } = props.planter.featuredTrees.trees[0];
+      if (lat && lon) {
+        const { countries } = await utils.requestAPI(
+          `/countries?lat=${lat}&lon=${lon}`,
+        );
+        if (countries?.length) {
+          const [first] = countries;
+          props.planter.country = first;
+        }
+      }
+    }
   }
 
   return {

--- a/src/theme.js
+++ b/src/theme.js
@@ -139,10 +139,10 @@ const theme = createTheme(colorTheme, {
       stylesOverrides: {
         root: {
           letterSpacing: 0,
-        }
-      }
-    }
-  }
+        },
+      },
+    },
+  },
 });
 
 export default theme;


### PR DESCRIPTION
# Description

Using the planter's first featured tree geo (lat/lon) look up the country and display as the planter's country.

Fixes #446

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

http://localhost:3001/planters/5410

<img width="879" alt="Screen Shot 2022-02-06 at 5 13 43 PM" src="https://user-images.githubusercontent.com/64604698/152710391-0905c851-9f8d-4bc1-9bef-7b5b0caa5b78.png">

# How Has This Been Tested?

not yet

- [x] Cypress integration
- [x] Cypress component tests
- [x] Jest unit tests

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
