### PR TITLE
style: refine planter image

### DIFF
--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -100,8 +100,8 @@ export default function Planter({ planter }) {
         variant="rounded"
         sx={{
           width: '100%',
-          height: '688px',
-          borderRadius: 6,
+          height: '600px',
+          borderRadius: 35,
           mt: 11,
           mb: [6, 10],
         }}


### PR DESCRIPTION
Fixes issue [#425](https://github.com/Greenstand/treetracker-web-map-client/issues/425)

Some changes made to planter profile image css properties.

![Screenshot from 2022-02-06 22-05-42](https://user-images.githubusercontent.com/79326421/152787255-a33b2e95-4bc7-4877-949f-3f41dd528aee.png)

