### PR TITLE
feat: zoom controls

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -155,6 +155,7 @@ function MapComponent() {
       filters: parameters,
       iconSuite: window.screen.width > 1199 ? 'ptk-b' : 'ptk-s',
       zoomControl: true,
+      zoomControlPosition: 'bottomright',
     });
     map.on('moveEnd', () => {
       log.warn('update url');

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -154,6 +154,7 @@ function MapComponent() {
       onError: handleError,
       filters: parameters,
       iconSuite: window.screen.width > 1199 ? 'ptk-b' : 'ptk-s',
+      zoomControl: true,
     });
     map.on('moveEnd', () => {
       log.warn('update url');


### PR DESCRIPTION
**Enable Map zoom controls**

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

<s>The google maps default zoom control location is on the top left.  I attempted to set the position to bottom right, but there is a race condition between the async google maps script loading and the greenstand map initialization.  Without some involved handling of those two events it's tough to set the zoomControlOptions.  Maybe that could be a follow up to this PR if someone can figure it out.  I realize this does not meet the requirement of zoom buttons on the **bottom right**. </s>

Fixes #332

## Dependency

https://github.com/Greenstand/treetracker-web-map-core/pull/86

This and its dependent PR can be merged/released in any order without causing issues.

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

<img width="1050" alt="Screen Shot 2022-02-12 at 8 11 46 AM" src="https://user-images.githubusercontent.com/64604698/153719156-0aeeaddf-2782-40dc-9e9d-bbb39320baa6.png">


# How Has This Been Tested?

- [X] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
