### PR TITLE
Show FB button permanently

### DIFF
--- a/src/components/common/CustomImageWrapper.js
+++ b/src/components/common/CustomImageWrapper.js
@@ -135,21 +135,20 @@ function CustomImageWrapper({ imageUrl, timeCreated, treeId }) {
           </Grid>
         </InfoWrapper>
       )}
-      {isShown && (
-        <InfoWrapper bottom={20}>
-          <Grid
-            container
-            direction="row"
-            justifyContent="center"
-            alignItems="center"
-            columnGap={2}
-            width="100%"
-            height="100%"
-          >
-            <LikeButton treeId={treeId} />
-          </Grid>
-        </InfoWrapper>
-      )}
+
+      <InfoWrapper bottom={20}>
+        <Grid
+          container
+          direction="row"
+          justifyContent="center"
+          alignItems="center"
+          columnGap={2}
+          width="100%"
+          height="100%"
+        >
+          <LikeButton treeId={treeId} />
+        </Grid>
+      </InfoWrapper>
       <img src={imageUrl} alt="tree" className={classes.image} />
     </Box>
   );


### PR DESCRIPTION
# Description

[comment]: #445 keep the FB button permanently on the photo now'

Fixes #445 The like button animation is slow

## Type of change

[comment]: 

- Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

# How Has This Been Tested?

- Cypress integration
