### PR TITLE
build: update nextjs to stable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "leaflet.gridlayer.googlemutant": "^0.12.1",
         "loglevel": "^1.7.0",
         "moment": "^2.29.1",
-        "next": "^12.0.11-canary.15",
+        "next": "^12.1.0",
         "next-images": "^1.8.1",
         "prop-types": "^15.7.2",
         "react": "^17.0.2",
@@ -69,7 +69,7 @@
         "lint-staged": "^11.2.6",
         "msw": "^0.36.8",
         "next-router-mock": "^0.6.3",
-        "nock": "^13.2.4",
+        "nock": "^13.1.3",
         "prettier": "^2.4.1",
         "sort-package-json": "^1.53.1",
         "start-server-and-test": "^1.14.0",
@@ -3571,8 +3571,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "12.0.11-canary.15",
-      "license": "MIT"
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.0.tgz",
+      "integrity": "sha512-nrIgY6t17FQ9xxwH3jj0a6EOiQ/WDHUos35Hghtr+SWN/ntHIQ7UpuvSi0vaLzZVHQWaDupKI+liO5vANcDeTQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "12.0.7",
@@ -3582,12 +3583,103 @@
         "glob": "7.1.7"
       }
     },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.0.11-canary.15",
+    "node_modules/@next/swc-android-arm64": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.0.tgz",
+      "integrity": "sha512-/280MLdZe0W03stA69iL+v6I+J1ascrQ6FrXBlXGCsGzrfMaGr7fskMa0T5AhQIVQD4nA/46QQWxG//DYuFBcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.0.tgz",
+      "integrity": "sha512-R8vcXE2/iONJ1Unf5Ptqjk6LRW3bggH+8drNkkzH4FLEQkHtELhvcmJwkXcuipyQCsIakldAXhRbZmm3YN1vXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.0.tgz",
+      "integrity": "sha512-ieAz0/J0PhmbZBB8+EA/JGdhRHBogF8BWaeqR7hwveb6SYEIJaDNQy0I+ZN8gF8hLj63bEDxJAs/cEhdnTq+ug==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.0.tgz",
+      "integrity": "sha512-njUd9hpl6o6A5d08dC0cKAgXKCzm5fFtgGe6i0eko8IAdtAPbtHxtpre3VeSxdZvuGFh+hb0REySQP9T1ttkog==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.0.tgz",
+      "integrity": "sha512-OqangJLkRxVxMhDtcb7Qn1xjzFA3s50EIxY7mljbSCLybU+sByPaWAHY4px97ieOlr2y4S0xdPKkQ3BCAwyo6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.0.tgz",
+      "integrity": "sha512-hB8cLSt4GdmOpcwRe2UzI5UWn6HHO/vLkr5OTuNvCJ5xGDwpPXelVkYW/0+C3g5axbDW2Tym4S+MQCkkH9QfWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.0.tgz",
+      "integrity": "sha512-OKO4R/digvrVuweSw/uBM4nSdyzsBV5EwkUeeG4KVpkIZEe64ZwRpnFB65bC6hGwxIBnTv5NMSnJ+0K/WmG78A==",
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
       "os": [
         "linux"
@@ -3597,14 +3689,60 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.0.11-canary.15",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.0.tgz",
+      "integrity": "sha512-JohhgAHZvOD3rQY7tlp7NlmvtvYHBYgY0x5ZCecUT6eCCcl9lv6iV3nfu82ErkxNk1H893fqH0FUpznZ/H3pSw==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.0.tgz",
+      "integrity": "sha512-T/3gIE6QEfKIJ4dmJk75v9hhNiYZhQYAoYm4iVo1TgcsuaKLFa+zMPh4056AHiG6n9tn2UQ1CFE8EoybEsqsSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.0.tgz",
+      "integrity": "sha512-iwnKgHJdqhIW19H9PRPM9j55V6RdcOo6rX+5imx832BCWzkDbyomWnlzBfr6ByUYfhohb8QuH4hSGEikpPqI0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.0.tgz",
+      "integrity": "sha512-aBvcbMwuanDH4EMrL2TthNJy+4nP59Bimn8egqv6GHMVj0a44cU6Au4PjOhLNqEh9l+IpRGBqMTzec94UdC5xg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 10"
@@ -14666,10 +14804,11 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "12.0.11-canary.15",
-      "license": "MIT",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.1.0.tgz",
+      "integrity": "sha512-s885kWvnIlxsUFHq9UGyIyLiuD0G3BUC/xrH0CEnH5lHEWkwQcHOORgbDF0hbrW9vr/7am4ETfX4A7M6DjrE7Q==",
       "dependencies": {
-        "@next/env": "12.0.11-canary.15",
+        "@next/env": "12.1.0",
         "caniuse-lite": "^1.0.30001283",
         "postcss": "8.4.5",
         "styled-jsx": "5.0.0",
@@ -14682,17 +14821,17 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm64": "12.0.11-canary.15",
-        "@next/swc-darwin-arm64": "12.0.11-canary.15",
-        "@next/swc-darwin-x64": "12.0.11-canary.15",
-        "@next/swc-linux-arm-gnueabihf": "12.0.11-canary.15",
-        "@next/swc-linux-arm64-gnu": "12.0.11-canary.15",
-        "@next/swc-linux-arm64-musl": "12.0.11-canary.15",
-        "@next/swc-linux-x64-gnu": "12.0.11-canary.15",
-        "@next/swc-linux-x64-musl": "12.0.11-canary.15",
-        "@next/swc-win32-arm64-msvc": "12.0.11-canary.15",
-        "@next/swc-win32-ia32-msvc": "12.0.11-canary.15",
-        "@next/swc-win32-x64-msvc": "12.0.11-canary.15"
+        "@next/swc-android-arm64": "12.1.0",
+        "@next/swc-darwin-arm64": "12.1.0",
+        "@next/swc-darwin-x64": "12.1.0",
+        "@next/swc-linux-arm-gnueabihf": "12.1.0",
+        "@next/swc-linux-arm64-gnu": "12.1.0",
+        "@next/swc-linux-arm64-musl": "12.1.0",
+        "@next/swc-linux-x64-gnu": "12.1.0",
+        "@next/swc-linux-x64-musl": "12.1.0",
+        "@next/swc-win32-arm64-msvc": "12.1.0",
+        "@next/swc-win32-ia32-msvc": "12.1.0",
+        "@next/swc-win32-x64-msvc": "12.1.0"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -21904,7 +22043,9 @@
       }
     },
     "@next/env": {
-      "version": "12.0.11-canary.15"
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.0.tgz",
+      "integrity": "sha512-nrIgY6t17FQ9xxwH3jj0a6EOiQ/WDHUos35Hghtr+SWN/ntHIQ7UpuvSi0vaLzZVHQWaDupKI+liO5vANcDeTQ=="
     },
     "@next/eslint-plugin-next": {
       "version": "12.0.7",
@@ -21913,12 +22054,70 @@
         "glob": "7.1.7"
       }
     },
+    "@next/swc-android-arm64": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.0.tgz",
+      "integrity": "sha512-/280MLdZe0W03stA69iL+v6I+J1ascrQ6FrXBlXGCsGzrfMaGr7fskMa0T5AhQIVQD4nA/46QQWxG//DYuFBcA==",
+      "optional": true
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.0.tgz",
+      "integrity": "sha512-R8vcXE2/iONJ1Unf5Ptqjk6LRW3bggH+8drNkkzH4FLEQkHtELhvcmJwkXcuipyQCsIakldAXhRbZmm3YN1vXg==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.0.tgz",
+      "integrity": "sha512-ieAz0/J0PhmbZBB8+EA/JGdhRHBogF8BWaeqR7hwveb6SYEIJaDNQy0I+ZN8gF8hLj63bEDxJAs/cEhdnTq+ug==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.0.tgz",
+      "integrity": "sha512-njUd9hpl6o6A5d08dC0cKAgXKCzm5fFtgGe6i0eko8IAdtAPbtHxtpre3VeSxdZvuGFh+hb0REySQP9T1ttkog==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.0.tgz",
+      "integrity": "sha512-OqangJLkRxVxMhDtcb7Qn1xjzFA3s50EIxY7mljbSCLybU+sByPaWAHY4px97ieOlr2y4S0xdPKkQ3BCAwyo6Q==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.0.tgz",
+      "integrity": "sha512-hB8cLSt4GdmOpcwRe2UzI5UWn6HHO/vLkr5OTuNvCJ5xGDwpPXelVkYW/0+C3g5axbDW2Tym4S+MQCkkH9QfWA==",
+      "optional": true
+    },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.0.11-canary.15",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.0.tgz",
+      "integrity": "sha512-OKO4R/digvrVuweSw/uBM4nSdyzsBV5EwkUeeG4KVpkIZEe64ZwRpnFB65bC6hGwxIBnTv5NMSnJ+0K/WmG78A==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.0.11-canary.15",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.0.tgz",
+      "integrity": "sha512-JohhgAHZvOD3rQY7tlp7NlmvtvYHBYgY0x5ZCecUT6eCCcl9lv6iV3nfu82ErkxNk1H893fqH0FUpznZ/H3pSw==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.0.tgz",
+      "integrity": "sha512-T/3gIE6QEfKIJ4dmJk75v9hhNiYZhQYAoYm4iVo1TgcsuaKLFa+zMPh4056AHiG6n9tn2UQ1CFE8EoybEsqsSw==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.0.tgz",
+      "integrity": "sha512-iwnKgHJdqhIW19H9PRPM9j55V6RdcOo6rX+5imx832BCWzkDbyomWnlzBfr6ByUYfhohb8QuH4hSGEikpPqI0Q==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.0.tgz",
+      "integrity": "sha512-aBvcbMwuanDH4EMrL2TthNJy+4nP59Bimn8egqv6GHMVj0a44cU6Au4PjOhLNqEh9l+IpRGBqMTzec94UdC5xg==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -29162,20 +29361,22 @@
       "version": "2.6.2"
     },
     "next": {
-      "version": "12.0.11-canary.15",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.1.0.tgz",
+      "integrity": "sha512-s885kWvnIlxsUFHq9UGyIyLiuD0G3BUC/xrH0CEnH5lHEWkwQcHOORgbDF0hbrW9vr/7am4ETfX4A7M6DjrE7Q==",
       "requires": {
-        "@next/env": "12.0.11-canary.15",
-        "@next/swc-android-arm64": "12.0.11-canary.15",
-        "@next/swc-darwin-arm64": "12.0.11-canary.15",
-        "@next/swc-darwin-x64": "12.0.11-canary.15",
-        "@next/swc-linux-arm-gnueabihf": "12.0.11-canary.15",
-        "@next/swc-linux-arm64-gnu": "12.0.11-canary.15",
-        "@next/swc-linux-arm64-musl": "12.0.11-canary.15",
-        "@next/swc-linux-x64-gnu": "12.0.11-canary.15",
-        "@next/swc-linux-x64-musl": "12.0.11-canary.15",
-        "@next/swc-win32-arm64-msvc": "12.0.11-canary.15",
-        "@next/swc-win32-ia32-msvc": "12.0.11-canary.15",
-        "@next/swc-win32-x64-msvc": "12.0.11-canary.15",
+        "@next/env": "12.1.0",
+        "@next/swc-android-arm64": "12.1.0",
+        "@next/swc-darwin-arm64": "12.1.0",
+        "@next/swc-darwin-x64": "12.1.0",
+        "@next/swc-linux-arm-gnueabihf": "12.1.0",
+        "@next/swc-linux-arm64-gnu": "12.1.0",
+        "@next/swc-linux-arm64-musl": "12.1.0",
+        "@next/swc-linux-x64-gnu": "12.1.0",
+        "@next/swc-linux-x64-musl": "12.1.0",
+        "@next/swc-win32-arm64-msvc": "12.1.0",
+        "@next/swc-win32-ia32-msvc": "12.1.0",
+        "@next/swc-win32-x64-msvc": "12.1.0",
         "caniuse-lite": "^1.0.30001283",
         "postcss": "8.4.5",
         "styled-jsx": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "leaflet.gridlayer.googlemutant": "^0.12.1",
     "loglevel": "^1.7.0",
     "moment": "^2.29.1",
-    "next": "^12.0.11-canary.15",
+    "next": "^12.1.0",
     "next-images": "^1.8.1",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",


### PR DESCRIPTION
Nextjs was updated to a canary release for #470. A new release version came out yesterday so we should update to avoid any possible issues in the unstable version. 

https://github.com/vercel/next.js/releases/tag/v12.1.0