### PR TITLE
fix: navbar loading before main content

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -4,9 +4,9 @@ import Fab from '@mui/material/Fab';
 import Paper from '@mui/material/Paper';
 import dynamic from 'next/dynamic';
 import { makeStyles } from 'models/makeStyles';
+import Navbar from './Navbar';
 
 const App = dynamic(() => import('./App'), { ssr: false });
-const Navbar = dynamic(() => import('./Navbar'), { ssr: false });
 
 const useStyles = makeStyles()((theme) => ({
   root: {

--- a/src/components/LayoutMobile.js
+++ b/src/components/LayoutMobile.js
@@ -2,10 +2,10 @@ import Box from '@mui/material/Box';
 import dynamic from 'next/dynamic';
 import { makeStyles } from 'models/makeStyles';
 import Drawer from './Drawer';
+import Navbar from './Navbar';
 import SearchFilter from './SearchFilter';
 
 const App = dynamic(() => import('./App'), { ssr: false });
-const Navbar = dynamic(() => import('./Navbar'), { ssr: false });
 
 const useStyles = makeStyles()((theme) => ({
   root: {

--- a/src/components/LayoutMobileB.js
+++ b/src/components/LayoutMobileB.js
@@ -1,8 +1,6 @@
 import Box from '@mui/material/Box';
-import dynamic from 'next/dynamic';
 import { makeStyles } from 'models/makeStyles';
-
-const Navbar = dynamic(() => import('./Navbar'), { ssr: false });
+import Navbar from './Navbar';
 
 const useStyles = makeStyles()((theme) => ({
   root: {

--- a/src/components/LayoutMobileC.js
+++ b/src/components/LayoutMobileC.js
@@ -1,8 +1,6 @@
 import Box from '@mui/material/Box';
-import dynamic from 'next/dynamic';
 import { makeStyles } from 'models/makeStyles';
-
-const Navbar = dynamic(() => import('./Navbar'), { ssr: false });
+import Navbar from './Navbar';
 
 const useStyles = makeStyles()((theme) => ({
   root: {


### PR DESCRIPTION
# Description

The navbar loads and shows up after the main content of the page. This was due to it being dynamically loaded. The dynamic loading is not needed for the navbar. It's a very small fix.

Fixes #500

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

https://user-images.githubusercontent.com/36883813/157023089-c51120fc-4827-4b31-b7a8-47feb93f2942.mp4

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
