### PR TITLE
fix: issue #495 move copyright panel behind drawer

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -90,6 +90,10 @@ a:hover {
   box-shadow: 0 0px 0px rgb(0 0 0 / 0%);
 }
 
+.leaflet-bottom {
+  z-index: 900 !important;
+}
+
 @keyframes slideInFromBottom {
   0% {
     opacity: 0;


### PR DESCRIPTION
# Description

Moved copyright panel behind drawer.

Fixes #495

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
![Screenshot from 2022-03-08 08-31-19](https://user-images.githubusercontent.com/31432331/157188310-e69b6716-2a93-476b-9c59-953d02f74849.png)

[comment]: # 'Please include screenshots of your changes if relevant.'
