### PR TITLE
feat: issue #475 add localstorage hook

### DIFF
--- a/src/context/themeContext.js
+++ b/src/context/themeContext.js
@@ -1,10 +1,11 @@
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import React from 'react';
+import useLocalStorage from 'hooks/useLocalStorage';
 
 const CustomThemeContext = React.createContext({ toggleColorMode: () => {} });
 
 export function CustomThemeProvider({ children }) {
-  const [mode, setMode] = React.useState('light');
+  const [mode, setMode] = useLocalStorage('theme', 'light');
 
   const colorMode = React.useMemo(
     () => ({
@@ -281,6 +282,7 @@ export function CustomThemeProvider({ children }) {
     }),
     [colorMode, theme],
   );
+
   return (
     <CustomThemeContext.Provider value={value}>
       <ThemeProvider theme={theme}>{children}</ThemeProvider>

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+// Get values from localstorage
+function getStorageValue(key, defaultValue) {
+  if (typeof window !== 'undefined') {
+    const saved = JSON.parse(localStorage.getItem(key));
+    return saved || defaultValue;
+  }
+  return defaultValue;
+}
+
+// Usage: Similar to useState. Accepts a key, value pair. For example:
+// const [mode, setMode] = useLocalStorage('theme', 'light');
+const useLocalStorage = (key, defaultValue) => {
+  const [value, setValue] = useState(() => getStorageValue(key, defaultValue));
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+
+  return [value, setValue];
+};
+
+export default useLocalStorage;


### PR DESCRIPTION
# Description

Usage: Similar to useState. Accepts a key, value pair. For example:
```
const [mode, setMode] = useLocalStorage('theme', 'light');
```

Fixes #475

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)
