### PR TITLE
fix: missing flags for 2 countries added back

### DIFF
--- a/src/models/utils.js
+++ b/src/models/utils.js
@@ -91,10 +91,10 @@ const formatDates = (date, format) =>
 const fixCountryNames = (countries) =>
   countries.map((country) => {
     if (country.name === 'Tanzania') {
-      return { ...country, name: 'Tanzania, United Republic of' };
+      return { ...country, name: 'United Republic of Tanzania' };
     }
     if (country.name === 'Democratic Republic of the Congo') {
-      return { ...country, name: 'Congo, the Democratic Republic of the' };
+      return { ...country, name: 'Democratic Republic of the Congo' };
     }
     return country;
   });


### PR DESCRIPTION
# Tanzania and DR of Congo flags were both missing

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

Fixes #532 
The fixCountryNames function in models/utils to get the correct Alpha2 code was changed. It shouldn't be necessary to have this function because the correct Alpha2 codes are fetched anyways, but kept both countries in that function to avoid any more issues.

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'
<img width="442" alt="Screen Shot 2022-04-26 at 5 52 13 PM" src="https://user-images.githubusercontent.com/76185224/165398629-2b1d05f7-7b94-42bf-833b-86c26d5b5e6b.png">
<img width="418" alt="Screen Shot 2022-04-26 at 5 52 08 PM" src="https://user-images.githubusercontent.com/76185224/165398631-4b12cb70-4667-472d-9e1c-c1a137f89cee.png">


# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
