### PR TITLE
fix: tiny css problem #552

### DIFF
--- a/src/components/LayoutEmbed.js
+++ b/src/components/LayoutEmbed.js
@@ -269,7 +269,12 @@ export default function Layout({ children, isFloatingDisabled }) {
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img alt="zoom-in" src={zoomIn} />
           </Box>
-          <Box onClick={handleZoomOut}>
+          <Box
+            onClick={handleZoomOut}
+            sx={{
+              '& img': { display: 'block' },
+            }}
+          >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img alt="zoom-out" src={zoomOut} />
           </Box>

--- a/src/style.css
+++ b/src/style.css
@@ -99,6 +99,7 @@ a:hover {
     opacity: 0;
     transform: translateY(100%);
   }
+
   100% {
     opacity: 1;
     transform: translateY(0);
@@ -148,4 +149,8 @@ a:hover {
   height: 500px;
   background-position: center;
   background-size: cover;
+}
+
+.mui-0 ~ .mui-0 img {
+  float: left;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -150,7 +150,3 @@ a:hover {
   background-position: center;
   background-size: cover;
 }
-
-.mui-1g16ym9 .mui-0 ~ .mui-0 img {
-  float: left;
-}

--- a/src/style.css
+++ b/src/style.css
@@ -151,6 +151,6 @@ a:hover {
   background-size: cover;
 }
 
-.mui-0 ~ .mui-0 img {
+.mui-1g16ym9 .mui-0 ~ .mui-0 img {
   float: left;
 }


### PR DESCRIPTION
# Description

Fixes Tiny CSS Issue #552

Before:
<img width="300" alt="Screen Shot 2565-05-06 at 19 46 10" src="https://user-images.githubusercontent.com/92221802/167199392-4e7c5e07-d0fb-4aa1-af3f-ed2fffd25c97.png">

After:
<img width="303" alt="Screen Shot 2565-05-06 at 19 46 54" src="https://user-images.githubusercontent.com/92221802/167199481-2d671729-5490-4a61-917b-20e314ff68ff.png">

