### PR TITLE
fix: #559

### DIFF
--- a/src/components/Share.js
+++ b/src/components/Share.js
@@ -1,7 +1,7 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Close from '@mui/icons-material/Close';
 import Code from '@mui/icons-material/Code';
 import Email from '@mui/icons-material/Email';
+import FacebookRoundedIcon from '@mui/icons-material/FacebookRounded';
 import ShareIcon from '@mui/icons-material/Share';
 import TwitterIcon from '@mui/icons-material/Twitter';
 import { Box, Typography, Tooltip } from '@mui/material';
@@ -190,7 +190,7 @@ function Share(props) {
             <Code />
           </CustomShareIcon>
           <CustomShareIcon handleOnClick={handleFaceBook}>
-            <FontAwesomeIcon icon={['fab', 'facebook-f']} />
+            <FacebookRoundedIcon />
           </CustomShareIcon>
           <CustomShareIcon handleOnClick={handleTwitter}>
             <TwitterIcon />


### PR DESCRIPTION
# Description
Resolves #559 

Fixes #559 

Used mui material icon instead of fontawesome

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots
![sc](https://user-images.githubusercontent.com/102795002/167587288-f9360c73-a112-41ee-a622-667ec6da23bd.png)

[comment]: # 'Please include screenshots of your changes if relevant.'

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
