### PR TITLE
fix: dev env path resolves #518

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_BASE=""
+NEXT_PUBLIC_BASE=/web-map-site

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0-beta.5",
       "dependencies": {
         "@emotion/cache": "^11.5.0",
         "@emotion/react": "^11.5.0",


### PR DESCRIPTION
# Description

simple fix, pushing to dev uses path in .env.dev, which was "". Changed this to /web-map-site so it can load resources correctly.

As a note, this will mean the new local url is [http://localhost:3000/web-map-site](http://localhost:3000/web-map-site). A simple workaround if preferred to keep as it was is to have a .env.local setting the path to "", and thats already ignored by git so it seems like a solid workflow for anyone who prefers to keep the classic url (such as having bookmarks already, etc). Happy to adjust if thats an incorrect assumption though, for example doing this in next instead of in the env. 

Fixes #518 

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)


