### PR TITLE
fix(sharebutton): added onClick to CustomShareIcon

### DIFF
--- a/src/components/common/CustomShareIcon.js
+++ b/src/components/common/CustomShareIcon.js
@@ -19,6 +19,7 @@ function CustomShareIcon({ handleOnClick, children, mailString }) {
           backgroundColor: 'rgba(0, 0, 0, 0.08)',
         },
       }}
+      onClick={handleOnClick}
     >
       {children}
     </IconButton>


### PR DESCRIPTION
# Description

[comment]: # added an onClick={handleOnClick} to CustonShareIcon.js, when handleOnClick was being used in Share.js it wasnt doing anything as it wasnt being told what to do

Fixes #562 


- [ x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ x] I have performed a self-review of my own code
- [x ] My changes generate no new warnings

![image](https://user-images.githubusercontent.com/63400531/169550814-cdb592be-8cf7-4bf3-8a0c-3aa98203a3d0.png)
