### PR TITLE
fix: next asset path resolves #518

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,5 +26,6 @@ module.exports = {
       },
     ];
   },
+  assetPrefix: process.env.NEXT_PUBLIC_BASE,
   basePath: process.env.NEXT_PUBLIC_BASE,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "2.0.0-beta.4",
+  "version": "2.0.0-beta.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "2.0.0-beta.4",
+      "version": "2.0.0-beta.5",
       "dependencies": {
         "@emotion/cache": "^11.5.0",
         "@emotion/react": "^11.5.0",


### PR DESCRIPTION
# Description
Opened this one as a draft to make sure im understanding the issue correctly first/avoid dupe PRs. 
 
Interesting info @dadiorchen provided in that comment on my last PR #572 as i've never noticed this issue using basePath, however I dont have a ton of experience in nextjs. It seems that [assetPrefix](https://nextjs.org/docs/api-reference/next.config.js/cdn-support-with-asset-prefix) may be the desired outcome here, this will make sure next assets are prefixed with the same base path. e.g. /web-map-site/demo/ or /web-map-site/ or, in the case of env.development, directly to the base. 

Is this a correct understanding of the issue? or should the assetPrefix always be /web-map-site/ regardless of demo or local development? or something else? 

Fixes #518 

## Type of change
Bug fix (non-breaking change which fixes an issue)
