### PR TITLE
fix: tree slider cards now are entire clickable

### DIFF
--- a/src/components/FeaturedTreesSlider/index.js
+++ b/src/components/FeaturedTreesSlider/index.js
@@ -6,6 +6,7 @@ import {
   Card,
   CardContent,
   CardMedia,
+  CardActionArea,
 } from '@mui/material';
 import { useRef } from 'react';
 import { useStyles } from './style'; // the style file
@@ -59,44 +60,52 @@ function FeaturedTreesSlider({ trees, size = null }) {
               scrollSnapAlign: 'center',
               scrollBehavior: 'smooth',
               // position: 'relative',
-              padding: (theme) => theme.spacing(5),
               borderRadius: (theme) => theme.spacing(4),
               // boxShadow: '0px 2px 16px rgba(34, 38, 41, 0.15)',
               // width: [152, 208],
               overflow: 'initial',
             }}
           >
-            <CardMedia
-              component="img"
-              image={tree.image_url}
-              alt="tree"
+            <CardActionArea
               sx={{
-                borderRadius: '16px',
-                transition: 'transform .5s',
-                width: 208,
-                height: 232,
-                minWidth: [144, 208],
+                padding: (theme) => theme.spacing(5),
+                borderRadius: (theme) => theme.spacing(4),
               }}
-            />
-            <CardContent>
-              <Typography
-                variant="h6"
-                sx={{
-                  fontSize: '20px',
-                  marginTop: 4,
-                }}
-              >
-                <Link href={`/trees/${tree.id}`}>Tree - {tree.id}</Link>
-              </Typography>
-              <Typography
-                variant="body1"
-                sx={{
-                  marginTop: 1.5,
-                }}
-              >
-                West-Smith-Nayer
-              </Typography>
-            </CardContent>
+            >
+              <Link href={`/trees/${tree.id}`}>
+                <CardMedia
+                  component="img"
+                  image={tree.image_url}
+                  alt="tree"
+                  sx={{
+                    borderRadius: '16px',
+                    transition: 'transform .5s',
+                    width: 208,
+                    height: 232,
+                    minWidth: [144, 208],
+                  }}
+                />
+                <CardContent>
+                  <Typography
+                    variant="h6"
+                    sx={{
+                      fontSize: '20px',
+                      marginTop: 4,
+                    }}
+                  >
+                    Tree - {tree.id}
+                  </Typography>
+                  <Typography
+                    variant="body1"
+                    sx={{
+                      marginTop: 1.5,
+                    }}
+                  >
+                    West-Smith-Nayer
+                  </Typography>
+                </CardContent>
+              </Link>
+            </CardActionArea>
           </Card>
         ))}
       </Grid>


### PR DESCRIPTION
# Description

This changes make the trees slider cards entire clickable instead of the id text only.

Fixes #578 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

<img width="619" alt="Screen Shot 2022-05-21 at 1 30 25 PM" src="https://user-images.githubusercontent.com/51935560/169662785-888bef39-682c-4a7b-9f9a-0d7c99fcbeab.png">

# How Has This Been Tested?

- [x] Jest unit tests

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
