### PR TITLE
fix: shortened gps location numbers

### DIFF
--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -75,6 +75,15 @@ export default function Tree({
 
   function handleShare() {}
 
+  // shorten tree.lat, tree.lon down to 5 decimal points
+  function shortenLongLat(number, digits) {
+    const multiplier = 10 ** digits;
+    const numAdjust = number * multiplier;
+    const shortenNum = Math[numAdjust < 0 ? 'ceil' : 'floor'](numAdjust);
+
+    return shortenNum / multiplier;
+  }
+
   function handleMax(url) {
     window.open(url, '_blank');
   }
@@ -372,7 +381,10 @@ export default function Tree({
         )}
         {tree.lat && tree.lon && (
           <TreeTag
-            TreeTagValue={`${tree.lat}, ${tree.lon}`}
+            TreeTagValue={`${shortenLongLat(tree.lat, 5)}, ${shortenLongLat(
+              tree.lon,
+              5,
+            )}`}
             title="Latitude, Longitude"
             icon={<img src={globalIcon} alt="lat,lon" />}
           />


### PR DESCRIPTION
# Description

[comment]: # 
Fixes #579 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x ] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![lat,lon](https://user-images.githubusercontent.com/63400531/169993441-1e137b17-6df1-4f24-809c-259fcd009168.png)



# How Has This Been Tested?

no cypress file for [treeid].js

# Checklist:

- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
