### PR TITLE
fix: adjusted box height to fix mobile scrolling

### DIFF
--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -397,7 +397,7 @@ export default function Tree({
           />
         )}
       </Box>
-      <Box height={20} />
+      <Box height={225} />
     </Box>
   );
 }


### PR DESCRIPTION
# Description

[comment]: # 
Fixes #597 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [ x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![image](https://user-images.githubusercontent.com/63400531/170231152-e7a9f990-49ba-4c4b-8dc9-75bcb4931702.png)



# How Has This Been Tested?

no cypress file for [treeid].js
I added a bunch of extra <TreeTag /> just to make sure it would look the same incase you added more to the page, and it looks exactly the same even with 20 treetags. I also looked at it on every mobile device in chrome developer tools and they are all able to scroll to the bottom and see everything.

# Checklist:

- [x ] I have performed a self-review of my own code
- [x ] My changes generate no new warnings
