### PR TITLE
feat: display tree species or country rather than tree name

### DIFF
--- a/src/components/FeaturedTreesSlider/index.js
+++ b/src/components/FeaturedTreesSlider/index.js
@@ -94,7 +94,7 @@ function FeaturedTreesSlider({ trees, size = null }) {
                   marginTop: 1.5,
                 }}
               >
-                West-Smith-Nayer
+                {tree.species ? `${tree.species_name}` : `${tree.country_name}`}
               </Typography>
             </CardContent>
           </Card>


### PR DESCRIPTION
# Description

# 'FeaturedTreesSlider displays the tree species if any, if the tree has no species specified, then it displays the country where the tree is.'

Fixes #577 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)


## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'


# Checklist:

- [x] I have performed a self-review of my own code

- [x] My changes generate no new warnings

