### PR TITLE
fix: repeated forward slash in href

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -79,7 +79,7 @@ function MapComponent() {
     const url = new URL(window.location.href);
     const { timeline } = url.searchParams;
     router.push(
-      `/${prefix}/trees/${tree.id}?embed=${isEmbed ? 'true' : 'false'}${
+      `${prefix}/trees/${tree.id}?embed=${isEmbed ? 'true' : 'false'}${
         timeline ? `&timeline=${timeline}` : ''
       }`,
     );


### PR DESCRIPTION
# Description
Fixes the error thrown by the repeated forward slash in href when switching between trees.

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots
Bug occurs when switching between the trees
:-:
![image](https://user-images.githubusercontent.com/31519867/173663946-c7b2f4dc-a94a-48dd-8872-0bfa27dc0122.png)

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
