### PR TITLE
fix: react prop warning

### DIFF
--- a/src/components/InformationCard1.js
+++ b/src/components/InformationCard1.js
@@ -43,8 +43,6 @@ function InformationCard1({
       elevation={0}
       className={classes.container}
       display="flex"
-      flexDirection="column"
-      justifyContent="space-between"
       sx={{
         bgcolor: (t) =>
           t.palette.mode === 'light'
@@ -60,6 +58,8 @@ function InformationCard1({
         height: 'fit-content',
         p: [4, 6],
         borderRadius: 4,
+        flexDirection: 'column',
+        justifyContent: 'space-between',
       }}
     >
       <Box display="flex" alignItems="center">


### PR DESCRIPTION
# Description
When passing style props directly to a MUI component React gives an annoying warning. These props should be passed through the `sx` prop.

```js
Warning: React does not recognize the `flexDirection` prop on a DOM element.
If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `flexdirection` instead.
If you accidentally passed it from a parent component, remove it from the DOM element.
```

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
