### PR TITLE
PR577: Display tree species or country rather than tree name #577

### DIFF
--- a/src/components/FeaturedTreesSlider/index.js
+++ b/src/components/FeaturedTreesSlider/index.js
@@ -8,6 +8,7 @@ import {
   CardMedia,
 } from '@mui/material';
 import { useRef, useState, useEffect } from 'react';
+import { getTreeSpecies } from 'models/trees';
 import { debounce } from 'models/utils';
 import { useStyles } from './style'; // the style file
 import { getThumbnailImageUrls } from '../../models/utils';
@@ -121,7 +122,7 @@ function FeaturedTreesSlider({ trees, size = null, isMobile }) {
                   marginTop: 1.5,
                 }}
               >
-                West-Smith-Nayer
+                {getTreeSpecies(tree)}
               </Typography>
             </CardContent>
           </Card>

--- a/src/models/trees.js
+++ b/src/models/trees.js
@@ -1,0 +1,10 @@
+export const DEFAULT_FEATURED_TREES_SPECIES = 'West-Smith-Nayer';
+
+export function getTreeSpecies(tree) {
+  if (!tree) return DEFAULT_FEATURED_TREES_SPECIES;
+  if (tree.species_name) return tree.species_name;
+  if (tree.species) return tree.species;
+  if (tree.country_name) return tree.country_name;
+
+  return DEFAULT_FEATURED_TREES_SPECIES;
+}

--- a/src/models/trees.test.js
+++ b/src/models/trees.test.js
@@ -1,0 +1,36 @@
+import { DEFAULT_FEATURED_TREES_SPECIES, getTreeSpecies } from './trees';
+
+describe('Trees Model', () => {
+  it('getTreeSpecies', () => {
+    const tree1 = {
+      country_name: 'Tanzania',
+      species: 'Palm tree'
+    }
+    const tree2 = {
+      country_name: 'Tanzania',
+      species: null,
+      species_name: 'SpeciesName'
+    }
+    const tree3 = {
+      country_name: 'Tanzania',
+      species: 'Palm tree',
+      species_name: 'SpeciesName'
+    }
+    const tree4 = {
+      country_name: null,
+      species: null,
+      species_name: null,
+    }
+    const tree5 = {
+      country_name: 'Tanzania',
+      species: null,
+      species_name: null,
+    }
+
+    expect(getTreeSpecies(tree1)).toBe('Palm tree');
+    expect(getTreeSpecies(tree2)).toBe('SpeciesName');
+    expect(getTreeSpecies(tree3)).toBe('SpeciesName');
+    expect(getTreeSpecies(tree4)).toBe(DEFAULT_FEATURED_TREES_SPECIES);
+    expect(getTreeSpecies(tree5)).toBe('Tanzania');
+  })
+})


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

fix #577 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'
current API doesn't have filled values, attach the screenshot from Cypress component tests
![image](https://user-images.githubusercontent.com/11030075/177524502-e2b77ba3-751f-4f6d-bba9-799fb5eb472e.png)


# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [x] Jest unit tests
