### PR TITLE
fix(pages/trees): drawer not scrolling tree info and improvement of t…

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -247,7 +247,7 @@ export default function Drawer(props) {
           top: 0,
           left: 0,
           width: '100%',
-          height: '100vh',
+          height: '100%',
           transition: 'transform 125ms cubic-bezier(0, 0, 0.2, 1) 0ms',
           // transform: 'translateY(500px)',
           zIndex: '999',

--- a/src/components/common/TreeTag.js
+++ b/src/components/common/TreeTag.js
@@ -39,6 +39,7 @@ function TreeTagComponent({ TreeTagValue, title, icon }) {
         borderStyle: 'solid',
         p: (t) => [t.spacing(3, 4), t.spacing(4.75, 6)],
         height: 'auto',
+        width: '100%',
       }}
       color="secondary"
       icon={<Box m={1}>{icon}</Box>}

--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -6,11 +6,12 @@ import NavigationOutlinedIcon from '@mui/icons-material/NavigationOutlined';
 import RoomOutlinedIcon from '@mui/icons-material/RoomOutlined';
 import { useMediaQuery, useTheme, SvgIcon, Avatar } from '@mui/material';
 import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
 import Portal from '@mui/material/Portal';
 import Typography from '@mui/material/Typography';
 import log from 'loglevel';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import CustomImageWrapper from 'components/common/CustomImageWrapper';
 import { useDrawerContext } from 'context/DrawerContext';
 import { getOrganizationById, getPlanterById, getTreeById } from 'models/api';
@@ -74,6 +75,9 @@ export default function Tree({
 
   const { setTitlesData } = useDrawerContext();
 
+  const [treeInfoHeight, setTreeInfoHeight] = useState(0);
+  const treeInfoHeightRef = useRef();
+
   log.warn('map:', mapContext);
 
   function handleShare() {}
@@ -100,6 +104,11 @@ export default function Tree({
   }, [setTitlesData, tree.id, tree.token_id, tree.verified]);
 
   useEffect(() => {
+    setTreeInfoHeight(treeInfoHeightRef.current.clientHeight);
+    console.log('height:', treeInfoHeightRef.current.clientHeight);
+  }, []);
+
+  useEffect(() => {
     // manipulate the map
     if (mapContext.map && tree?.lat && tree?.lon) {
       mapContext.map.flyTo(tree.lat, tree.lon, 16);
@@ -118,6 +127,7 @@ export default function Tree({
           padding: (t) => [t.spacing(0, 4), 4],
         },
       ]}
+      style={{ height: `calc(100% + ${treeInfoHeight}px)` }}
     >
       {/* <IsMobileScreen>
         <DrawerTitle />
@@ -358,58 +368,72 @@ export default function Tree({
           {
             fontSize: [24, 28],
             lineHeight: (t) => [t.spacing(7.25), t.spacing(8.5)],
-            mt: (t) => [t.spacing(14), t.spacing(26)],
+            mt: (t) => [t.spacing(14), t.spacing(20)],
+            mb: (t) => [t.spacing(14), t.spacing(15 * 0.6)],
           },
           nextExtraIsEmbed && {
-            mt: (t) => [t.spacing(14), t.spacing(26 * 0.6)],
+            mt: (t) => [t.spacing(14), t.spacing(20 * 0.6)],
+            mb: (t) => [t.spacing(14), t.spacing(15 * 0.6)],
           },
         ]}
       >
         Tree Info
       </Typography>
-      <Box className={classes.tabBox}>
-        <TreeTag
-          TreeTagValue={new Date(tree.time_created).toLocaleDateString()}
-          title="Planted on"
-          icon={<img src={calendarIcon} alt="calendar" />}
-        />
-        <TreeTag
-          TreeTagValue="Tanzania"
-          title="Located in"
-          icon={<img src={location} alt="location" />}
-        />
+      <Grid container spacing={2} ref={treeInfoHeightRef}>
+        <Grid item xs={6}>
+          <TreeTag
+            TreeTagValue={new Date(tree.time_created).toLocaleDateString()}
+            title="Planted on"
+            icon={<img src={calendarIcon} alt="calendar" />}
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <TreeTag
+            TreeTagValue="Tanzania"
+            title="Located in"
+            icon={<img src={location} alt="location" />}
+          />
+        </Grid>
         {tree.age && (
-          <TreeTag
-            TreeTagValue={tree.age}
-            title="Age"
-            icon={<img src={historyIcon} alt="age" />}
-          />
-        )}
-        {tree.gps_accuracy && (
-          <TreeTag
-            TreeTagValue={tree.gps_accuracy}
-            title="GPS Accuracy"
-            icon={<img src={accuracyIcon} alt="accuracy" />}
-          />
+          <Grid item xs={6}>
+            <TreeTag
+              TreeTagValue={tree.age}
+              title="Age"
+              icon={<img src={historyIcon} alt="age" />}
+            />
+          </Grid>
         )}
         {tree.lat && tree.lon && (
-          <TreeTag
-            TreeTagValue={`${shortenLongLat(tree.lat, 5)}, ${shortenLongLat(
-              tree.lon,
-              5,
-            )}`}
-            title="Latitude, Longitude"
-            icon={<img src={globalIcon} alt="lat,lon" />}
-          />
+          <Grid item xs={12} sm={6}>
+            <TreeTag
+              TreeTagValue={`${shortenLongLat(tree.lat, 5)}, ${shortenLongLat(
+                tree.lon,
+                5,
+              )}`}
+              title="Latitude, Longitude"
+              icon={<img src={globalIcon} alt="lat,lon" />}
+            />
+          </Grid>
+        )}
+        {tree.gps_accuracy && (
+          <Grid item xs={6}>
+            <TreeTag
+              TreeTagValue={tree.gps_accuracy}
+              title="GPS Accuracy"
+              icon={<img src={accuracyIcon} alt="accuracy" />}
+            />
+          </Grid>
         )}
         {tree.token_id && (
-          <TreeTag
-            TreeTagValue={tree.token_id}
-            title="Token ID"
-            icon={<img src={tokenIcon} alt="token" />}
-          />
+          <Grid item xs={6}>
+            <TreeTag
+              TreeTagValue={tree.token_id}
+              title="Token ID"
+              icon={<img src={tokenIcon} alt="token" />}
+            />
+          </Grid>
         )}
-      </Box>
+      </Grid>
       <Box height={20} />
     </Box>
   );


### PR DESCRIPTION
# Description

1. Fix Swipeable Drawer not showing the Tree Info Section on mobile devices: I tried changing the Page Component in the drawer.js file but it did not work, so I modified the [treeid].js page to set the main Box height accordingly to 100% + the height of the Tree Info Section Items.

2. Small change in the Tree Info Chips, to make them all look the same size, from my point of view it looks better to have them equally distributed on the page.  

Fixes #597 Swipeable Drawer not showing the Tree Info Section on mobile devices

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

**Drawer component:**

![fix_scroll](https://user-images.githubusercontent.com/45722406/178148766-a6b7d2f7-5bbd-471c-ade5-f76febed1048.png)

**Tree Info Chips:**

**_Before:_**

![before_grid](https://user-images.githubusercontent.com/45722406/178148813-3d4fe98f-ac0c-408a-a3c5-964812cc3bd2.png)

**_After:_**

![improve_info](https://user-images.githubusercontent.com/45722406/178148826-dcb229d0-ab46-4a73-a928-808ef51700ec.png)

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
