### PR TITLE
refactor: improve render theme customization

### DIFF
--- a/src/components/playground/ColorInput.cy.js
+++ b/src/components/playground/ColorInput.cy.js
@@ -1,16 +1,25 @@
+import { PlaygroundProvider } from 'context/playgroundContext';
 import ColorInput from './ColorInput';
 import { mountWithTheme as mount } from '../../models/test-utils';
 
 describe('Color Input', () => {
   const name = 'main';
-  const value = '#ff7';
+  const path = `palette.dark.primary.${name}`;
 
   it('renders', () => {
-    mount(<ColorInput label={name} initial={value} onChange={console.log} />);
+    mount(
+      <PlaygroundProvider>
+        <ColorInput label={name} path={path} />
+      </PlaygroundProvider>,
+    );
   });
 
   it('gives error on invalid syntax', () => {
-    mount(<ColorInput label={name} initial={value} onChange={console.log} />);
+    mount(
+      <PlaygroundProvider>
+        <ColorInput label={name} path={path} />
+      </PlaygroundProvider>,
+    );
     cy.get('.MuiFormControl-root').type('z').contains('Invalid syntax');
   });
 });

--- a/src/components/playground/ColorInput.js
+++ b/src/components/playground/ColorInput.js
@@ -1,16 +1,15 @@
 import { Box, TextField } from '@mui/material';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { usePlaygroundUtils } from '../../context/playgroundContext';
 import { propRules } from '../../models/themePlaygroundOptions';
 
 function ColorInput(props) {
-  const { label, initial, onChange } = props;
-  const [value, setValue] = useState(initial);
+  const { path, label, onChange } = props;
+  const { getPropByPath } = usePlaygroundUtils();
+  const initialValue = getPropByPath(path);
+  const [value, setValue] = useState(initialValue);
   const [isValid, setValid] = useState(true);
   const isGradient = /gradient/i.test(label);
-
-  useEffect(() => {
-    setValue(initial);
-  }, [initial]);
 
   const handleChange = (e) => {
     const userValue = e.target.value;

--- a/src/components/playground/ColorInput.js
+++ b/src/components/playground/ColorInput.js
@@ -4,8 +4,8 @@ import { usePlaygroundUtils } from '../../context/playgroundContext';
 import { propRules } from '../../models/themePlaygroundOptions';
 
 function ColorInput(props) {
-  const { path, label, onChange } = props;
-  const { getPropByPath } = usePlaygroundUtils();
+  const { path, label } = props;
+  const { getPropByPath, setPropByPath } = usePlaygroundUtils();
   const initialValue = getPropByPath(path);
   const [value, setValue] = useState(initialValue);
   const [isValid, setValid] = useState(true);
@@ -18,7 +18,7 @@ function ColorInput(props) {
 
     if (!isGradient) if (!propRules.color.test(userValue)) return;
     setValid(true);
-    onChange({ propName: label, newValue: userValue });
+    setPropByPath(path, userValue);
   };
 
   return (

--- a/src/components/playground/ColorThumbnail.cy.js
+++ b/src/components/playground/ColorThumbnail.cy.js
@@ -1,15 +1,18 @@
+import { PlaygroundProvider } from 'context/playgroundContext';
 import ColorThumbnail from './ColorThumbnail';
 import { mountWithTheme as mount } from '../../models/test-utils';
 
 describe('Color Thumbnail', () => {
-  const color = '#ff7';
+  const path = 'palette.dark.primary.main';
 
   it('renders', () => {
     // thumbnail adjusts to height of parent
     mount(
-      <div style={{ height: '24px' }}>
-        <ColorThumbnail color={color} />
-      </div>,
+      <PlaygroundProvider>
+        <div style={{ height: '24px' }}>
+          <ColorThumbnail path={path} />
+        </div>
+      </PlaygroundProvider>,
     );
   });
 });

--- a/src/components/playground/ColorThumbnail.js
+++ b/src/components/playground/ColorThumbnail.js
@@ -1,6 +1,10 @@
 import { Box } from '@mui/material';
+import { usePlaygroundUtils } from '../../context/playgroundContext';
 
-function ColorThumbnail({ color }) {
+function ColorThumbnail({ path }) {
+  const { getPropByPath } = usePlaygroundUtils();
+  const color = getPropByPath(path);
+
   return (
     <Box
       sx={{

--- a/src/components/playground/SelectColorProp.cy.js
+++ b/src/components/playground/SelectColorProp.cy.js
@@ -4,7 +4,10 @@ import { mountWithTheme as mount } from '../../models/test-utils';
 
 describe('Select Color Prop', () => {
   const path = 'palette.light.primary';
-  const prop = 'main';
+  const prop = {
+    propName: 'primary',
+    options: ['main', 'light', 'dark', 'contrastText'],
+  };
 
   it('renders', () => {
     mount(
@@ -12,8 +15,8 @@ describe('Select Color Prop', () => {
         <SelectColorProp path={path} prop={prop} />
       </PlaygroundProvider>,
     );
-    cy.get('#select-color-main-header').contains(prop);
-    cy.get('#select-color-main-header').click();
+    cy.get(`#select-color-${prop.propName}-header`).contains(prop.propName);
+    cy.get(`#select-color-${prop.propName}-header`).click();
     cy.get('.MuiList-root').should('be.visible');
   });
 });

--- a/src/components/playground/SelectColorProp.js
+++ b/src/components/playground/SelectColorProp.js
@@ -15,10 +15,12 @@ import { usePlaygroundUtils } from '../../context/playgroundContext';
 
 function SelectColorProp(props) {
   const { prop, path } = props;
+  const { propName, options } = prop;
   const { getPropByPath, setPropByPath } = usePlaygroundUtils();
 
   const childProps = getPropByPath(path);
 
+  /* eslint-disable-next-line */
   const handleChange = ({ propName, newValue }) => {
     log.warn('prop changed', `${path}.${propName} with ${newValue}`);
     setPropByPath(`${path}.${propName}`, newValue);
@@ -41,8 +43,8 @@ function SelectColorProp(props) {
       >
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls={`select-color-${prop}-content`}
-          id={`select-color-${prop}-header`}
+          aria-controls={`select-color-${propName}-content`}
+          id={`select-color-${propName}-header`}
           sx={{
             background: '#eee',
           }}
@@ -59,7 +61,7 @@ function SelectColorProp(props) {
                 textTransform: 'capitalize',
               }}
             >
-              {prop}
+              {propName}
             </Typography>
             <Stack direction="row">
               {Object.values(childProps).map((color, idx) => (
@@ -74,7 +76,7 @@ function SelectColorProp(props) {
         </AccordionSummary>
         <AccordionDetails>
           <List>
-            {Object.entries(childProps).map(([name, value]) => (
+            {Object.entries(childProps).map(([name]) => (
               <ListItem
                 key={`color-input-${name}`}
                 sx={{
@@ -82,8 +84,8 @@ function SelectColorProp(props) {
                 }}
               >
                 <ColorInput
+                  path={`${path}.${name}`}
                   label={name}
-                  initial={value}
                   onChange={handleChange}
                 />
               </ListItem>

--- a/src/components/playground/SelectColorProp.js
+++ b/src/components/playground/SelectColorProp.js
@@ -8,23 +8,12 @@ import {
   AccordionDetails,
   Typography,
 } from '@mui/material';
-import log from 'loglevel';
 import ColorInput from './ColorInput';
 import ColorThumbnail from './ColorThumbnail';
-import { usePlaygroundUtils } from '../../context/playgroundContext';
 
 function SelectColorProp(props) {
   const { prop, path } = props;
   const { propName, options } = prop;
-  const { getPropByPath, setPropByPath } = usePlaygroundUtils();
-
-  const childProps = getPropByPath(path);
-
-  /* eslint-disable-next-line */
-  const handleChange = ({ propName, newValue }) => {
-    log.warn('prop changed', `${path}.${propName} with ${newValue}`);
-    setPropByPath(`${path}.${propName}`, newValue);
-  };
 
   return (
     <ListItem
@@ -64,11 +53,10 @@ function SelectColorProp(props) {
               {propName}
             </Typography>
             <Stack direction="row">
-              {Object.values(childProps).map((color, idx) => (
+              {options.map((option) => (
                 <ColorThumbnail
-                  /* eslint-disable-next-line */
-                  key={`color-thumbnail-${color}-${idx}`}
-                  color={color}
+                  key={`color-thumbnail-${propName}-${option}`}
+                  path={`${path}.${option}`}
                 />
               ))}
             </Stack>
@@ -76,18 +64,14 @@ function SelectColorProp(props) {
         </AccordionSummary>
         <AccordionDetails>
           <List>
-            {Object.entries(childProps).map(([name]) => (
+            {options.map((option) => (
               <ListItem
-                key={`color-input-${name}`}
+                key={`color-input-${option}`}
                 sx={{
                   px: 0,
                 }}
               >
-                <ColorInput
-                  path={`${path}.${name}`}
-                  label={name}
-                  onChange={handleChange}
-                />
+                <ColorInput path={`${path}.${option}`} label={option} />
               </ListItem>
             ))}
           </List>

--- a/src/components/playground/SelectTypographyProp.cy.js
+++ b/src/components/playground/SelectTypographyProp.cy.js
@@ -4,7 +4,16 @@ import { mountWithTheme as mount } from '../../models/test-utils';
 
 describe('Select Typography Prop', () => {
   const path = 'typography.h1';
-  const prop = 'h1';
+  const prop = {
+    propName: 'h1',
+    options: [
+      'fontFamily',
+      'fontWeight',
+      'fontSize',
+      'lineHeight',
+      'letterSpacing',
+    ],
+  };
 
   it('renders', () => {
     mount(
@@ -12,8 +21,10 @@ describe('Select Typography Prop', () => {
         <SelectTypographyProp path={path} prop={prop} />
       </PlaygroundProvider>,
     );
-    cy.get('#select-typography-h1-header').contains(prop);
-    cy.get('#select-typography-h1-header').click();
+    cy.get(`#select-typography-${prop.propName}-header`).contains(
+      prop.propName,
+    );
+    cy.get(`#select-typography-${prop.propName}-header`).click();
     cy.get('.MuiList-root').should('be.visible');
   });
 });

--- a/src/components/playground/SelectTypographyProp.js
+++ b/src/components/playground/SelectTypographyProp.js
@@ -8,23 +8,12 @@ import {
   AccordionDetails,
   Typography,
 } from '@mui/material';
-import log from 'loglevel';
 import TypographyInput from './TypographyInput';
 import TypographyThumbnail from './TypographyThumbnail';
-import { usePlaygroundUtils } from '../../context/playgroundContext';
 
 function SelectTypographyProp(props) {
   const { prop, path } = props;
   const { propName, options } = prop;
-  const { getPropByPath, setPropByPath } = usePlaygroundUtils();
-
-  const childProps = getPropByPath(path);
-
-  /* eslint-disable-next-line */
-  const handleChange = ({ propName, newValue }) => {
-    log.warn('prop changed', `${path}.${propName} with ${newValue}`);
-    setPropByPath(`${path}.${propName}`, newValue);
-  };
 
   return (
     <ListItem
@@ -43,8 +32,8 @@ function SelectTypographyProp(props) {
       >
         <AccordionSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls={`select-typography-${prop}-content`}
-          id={`select-typography-${prop}-header`}
+          aria-controls={`select-typography-${propName}-content`}
+          id={`select-typography-${propName}-header`}
           sx={{
             background: '#eee',
           }}
@@ -60,29 +49,22 @@ function SelectTypographyProp(props) {
             <TypographyThumbnail
               key={`typography-thumbnail-${propName}`}
               text={`style for ${propName}`}
-              previewStyle={childProps}
+              path={path}
             />
           </Stack>
         </AccordionSummary>
         <AccordionDetails>
           <List>
-            {Object.entries(childProps).map(
-              ([name, value]) =>
-                typeof value === 'string' && (
-                  <ListItem
-                    key={`typography-input-${name}`}
-                    sx={{
-                      px: 0,
-                    }}
-                  >
-                    <TypographyInput
-                      path={`${path}.${name}`}
-                      label={name}
-                      onChange={handleChange}
-                    />
-                  </ListItem>
-                ),
-            )}
+            {options.map((option) => (
+              <ListItem
+                key={`typography-input-${option}`}
+                sx={{
+                  px: 0,
+                }}
+              >
+                <TypographyInput path={`${path}.${option}`} label={option} />
+              </ListItem>
+            ))}
           </List>
         </AccordionDetails>
       </Accordion>

--- a/src/components/playground/SelectTypographyProp.js
+++ b/src/components/playground/SelectTypographyProp.js
@@ -15,10 +15,12 @@ import { usePlaygroundUtils } from '../../context/playgroundContext';
 
 function SelectTypographyProp(props) {
   const { prop, path } = props;
+  const { propName, options } = prop;
   const { getPropByPath, setPropByPath } = usePlaygroundUtils();
 
   const childProps = getPropByPath(path);
 
+  /* eslint-disable-next-line */
   const handleChange = ({ propName, newValue }) => {
     log.warn('prop changed', `${path}.${propName} with ${newValue}`);
     setPropByPath(`${path}.${propName}`, newValue);
@@ -54,10 +56,10 @@ function SelectTypographyProp(props) {
               width: 1,
             }}
           >
-            <Typography>{prop}</Typography>
+            <Typography>{propName}</Typography>
             <TypographyThumbnail
-              key={`typography-thumbnail-${prop}`}
-              text={`style for ${prop}`}
+              key={`typography-thumbnail-${propName}`}
+              text={`style for ${propName}`}
               previewStyle={childProps}
             />
           </Stack>
@@ -74,8 +76,8 @@ function SelectTypographyProp(props) {
                     }}
                   >
                     <TypographyInput
+                      path={`${path}.${name}`}
                       label={name}
-                      initial={value}
                       onChange={handleChange}
                     />
                   </ListItem>

--- a/src/components/playground/TypographyInput.cy.js
+++ b/src/components/playground/TypographyInput.cy.js
@@ -5,11 +5,12 @@ import { mountWithTheme as mount } from '../../models/test-utils';
 describe('Typography Input', () => {
   it('renders fontFamily', () => {
     const name = 'fontFamily';
-    const value = 'Lato';
+    const path = `typography.h1.${name}`;
+    const value = 'Montserrat';
 
     mount(
       <PlaygroundProvider>
-        <TypographyInput label={name} initial={value} onChange={console.log} />
+        <TypographyInput path={path} label={name} />
       </PlaygroundProvider>,
     );
     cy.get('.MuiFormControl-root').contains(name);

--- a/src/components/playground/TypographyInput.js
+++ b/src/components/playground/TypographyInput.js
@@ -1,16 +1,19 @@
 import { Box, TextField, InputAdornment } from '@mui/material';
 import { useState, useEffect } from 'react';
 import FontSelector from './FontSelector';
+import { usePlaygroundUtils } from '../../context/playgroundContext';
 import { propRules } from '../../models/themePlaygroundOptions';
 
 function TypographyInput(props) {
-  const { label, initial, onChange } = props;
-  const [value, setValue] = useState(initial);
+  const { path, label, onChange } = props;
+  const { getPropByPath } = usePlaygroundUtils();
+  const initialValue = getPropByPath(path);
+  const [value, setValue] = useState(initialValue);
   const [isValid, setValid] = useState(true);
 
   useEffect(() => {
-    setValue(initial);
-  }, [initial]);
+    setValue(initialValue);
+  }, [initialValue]);
 
   const handleChange = (e) => {
     const userValue = e.target.value;

--- a/src/components/playground/TypographyInput.js
+++ b/src/components/playground/TypographyInput.js
@@ -5,8 +5,8 @@ import { usePlaygroundUtils } from '../../context/playgroundContext';
 import { propRules } from '../../models/themePlaygroundOptions';
 
 function TypographyInput(props) {
-  const { path, label, onChange } = props;
-  const { getPropByPath } = usePlaygroundUtils();
+  const { path, label } = props;
+  const { getPropByPath, setPropByPath } = usePlaygroundUtils();
   const initialValue = getPropByPath(path);
   const [value, setValue] = useState(initialValue);
   const [isValid, setValid] = useState(true);
@@ -22,7 +22,7 @@ function TypographyInput(props) {
 
     if (!propRules[label].test(userValue)) return;
     setValid(true);
-    onChange({ propName: label, newValue: userValue });
+    setPropByPath(path, userValue);
   };
 
   return (
@@ -45,11 +45,7 @@ function TypographyInput(props) {
         InputProps={{
           endAdornment: label === 'fontFamily' && (
             <InputAdornment position="end">
-              <FontSelector
-                handleChange={(val) =>
-                  onChange({ propName: label, newValue: val })
-                }
-              />
+              <FontSelector handleChange={(val) => setPropByPath(path, val)} />
             </InputAdornment>
           ),
         }}

--- a/src/components/playground/TypographyThumbnail.cy.js
+++ b/src/components/playground/TypographyThumbnail.cy.js
@@ -1,22 +1,16 @@
 import TypographyThumbnail from './TypographyThumbnail';
+import { PlaygroundProvider } from '../../context/playgroundContext';
 import { mountWithTheme as mount } from '../../models/test-utils';
 
 describe('Typography Thumbnail', () => {
   const prop = 'h1';
-  const styleProps = {
-    fontFamily: 'Montserrat',
-    fontWeight: 600,
-    fontSize: '48px',
-    lineHeight: '63px',
-    letterSpacing: '-0.01562em',
-  };
+  const path = `typography.${prop}`;
 
   it('renders', () => {
     mount(
-      <TypographyThumbnail
-        text={`style for ${prop}`}
-        previewStyle={styleProps}
-      />,
+      <PlaygroundProvider>
+        <TypographyThumbnail text={`style for ${prop}`} path={path} />,
+      </PlaygroundProvider>,
     );
     cy.contains(`style for ${prop}`);
   });

--- a/src/components/playground/TypographyThumbnail.js
+++ b/src/components/playground/TypographyThumbnail.js
@@ -1,6 +1,10 @@
 import { Box } from '@mui/material';
+import { usePlaygroundUtils } from '../../context/playgroundContext';
 
-function TypographyThumbnail({ text, previewStyle }) {
+function TypographyThumbnail({ text, path }) {
+  const { getPropByPath } = usePlaygroundUtils();
+  const previewStyle = getPropByPath(path);
+
   return (
     <Box
       sx={{

--- a/src/models/themePlaygroundOptions.js
+++ b/src/models/themePlaygroundOptions.js
@@ -1,16 +1,118 @@
 export const customizeOptions = {
-  palette: [
-    'background',
-    'primary',
-    'primaryLight',
-    'secondary',
-    'secondaryLight',
-    'greyLight',
-    'darkGrey',
-    'nearBlack',
-    'text',
-  ],
-  typography: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body1', 'body2', 'caption'],
+  palette: {
+    themeModeDependend: true,
+    options: {
+      background: [
+        'default',
+        'paper',
+        'paperDark',
+        'greenGradient',
+        'OrangeGreenGradient',
+      ],
+      primary: ['main', 'light', 'dark', 'contrastText'],
+      primaryLight: ['main'],
+      secondary: ['main', 'light', 'dark', 'contrastText'],
+      secondaryLight: ['main'],
+      notImportant: ['main'],
+      greyLight: ['main', 'contrastText'],
+      darkGrey: ['main', 'contrastText'],
+      nearBlack: ['main', 'contrastText'],
+      text: [
+        'primary',
+        'primaryReverse',
+        'disabled',
+        'secondary',
+        'text1',
+        'text2',
+      ],
+      error: ['main', 'light', 'dark', 'contrastText'],
+      warning: ['main', 'light', 'dark', 'contrastText'],
+      info: ['main', 'light', 'dark', 'contrastText'],
+      success: ['main', 'light', 'dark', 'contrastText'],
+    },
+  },
+  typography: {
+    themeModeDependend: false,
+    options: {
+      h1: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      h2: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      h3: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      h4: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      h5: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      h6: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      subtitle1: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      subtitle2: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      body1: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      body2: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+      caption: [
+        'fontFamily',
+        'fontWeight',
+        'fontSize',
+        'lineHeight',
+        'letterSpacing',
+      ],
+    },
+  },
 };
 
 export const predefinedFonts = ['Lato', 'Montserrat', 'Roboto'];
@@ -19,7 +121,8 @@ export const propRules = {
   color:
     /^#([a-f0-9]{6}|[a-f0-9]{3})$|^rgba?\(((25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*,\s*?){2}(25[0-5]|2[0-4]\d|1\d{1,2}|\d\d?)\s*,?\s*([01]\.?\d*?)?\)$/i,
   fontFamily:
-    /^((\w+(-\w+)?|inherit|initial|revert|revert-layer|unset)(, )?)+$/i,
+    // /^((\w+(-\w+)?|inherit|initial|revert|revert-layer|unset)(, )?)+$/i,
+    /.*/i,
   fontSize:
     /^-?(?:\d+(\.\d+)?(px|rem|em|ex)|\d{1,2}%|smaller|larger|medium|(x{1,2}-)?small|(x{1,3}-)?large|inherit|initial|revert|revert-layer|unset)$/i,
   fontWeight:

--- a/src/pages/admin/theme.js
+++ b/src/pages/admin/theme.js
@@ -449,22 +449,34 @@ function ThemeConfig() {
         >
           <CategoryTabPanel value={tabIndex} index={0}>
             <ToggleThemeMode />
-            {customizeOptions.palette.map((prop) => (
-              <SelectColorProp
-                key={`select-color-${prop}`}
-                prop={prop}
-                path={`palette.${themeType}.${prop}`}
-              />
-            ))}
+            {Object.entries(customizeOptions.palette.options).map(
+              ([propName, options]) => (
+                <SelectColorProp
+                  key={`select-color-${propName}`}
+                  prop={{ propName, options }}
+                  path={`palette${
+                    customizeOptions.palette.themeModeDependend
+                      ? `.${  themeType}`
+                      : ''
+                  }.${propName}`}
+                />
+              ),
+            )}
           </CategoryTabPanel>
           <CategoryTabPanel value={tabIndex} index={1}>
-            {customizeOptions.typography.map((prop) => (
-              <SelectTypographyProp
-                key={`select-typography-${prop}`}
-                prop={prop}
-                path={`typography.${prop}`}
-              />
-            ))}
+            {Object.entries(customizeOptions.typography.options).map(
+              ([propName, options]) => (
+                <SelectTypographyProp
+                  key={`select-typography-${propName}`}
+                  prop={{ propName, options }}
+                  path={`typography${
+                    customizeOptions.typography.themeModeDependend
+                      ? `.${  themeType}`
+                      : ''
+                  }.${propName}`}
+                />
+              ),
+            )}
           </CategoryTabPanel>
           <CategoryTabPanel value={tabIndex} index={2}>
             <FontCustomization />


### PR DESCRIPTION
# Description
Support rendering from the customizeOptions object.
Reduce 'prop drilling' by getting theme data in the lowest Components. 

Fixes #671

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Cypress component tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
