### PR TITLE
Legacy query redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -17,13 +17,13 @@ module.exports = {
   async rewrites() {
     return [
       {
-        source: '/planters/:planter_id(\\d{1,})/trees/:tree_id(\\d{1,})',
-        destination: '/trees/:tree_id(\\d{1,})',
+        source: '/planters/:planterId(\\d{1,})/trees/:treeId(\\d{1,})',
+        destination: '/trees/:treeId(\\d{1,})',
       },
       {
         source:
-          '/organizations/:organization_id(\\d{1,})/trees/:tree_id(\\d{1,})',
-        destination: '/trees/:tree_id(\\d{1,})',
+          '/organizations/:organizationId(\\d{1,})/trees/:treeId(\\d{1,})',
+        destination: '/trees/:treeId(\\d{1,})',
       },
       {
         source: '/map/:map_name(\\d{1,})',

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,5 @@
+/* eslint-disable require-await */
+
 const withImages = require('next-images');
 
 module.exports = {
@@ -12,7 +14,6 @@ module.exports = {
     ],
     disableStaticImages: true,
   },
-  // eslint-disable-next-line require-await
   async rewrites() {
     return [
       {
@@ -27,6 +28,34 @@ module.exports = {
       {
         source: '/map/:map_name(\\d{1,})',
         destination: '/?map=:map_name',
+      },
+    ];
+  },
+  async redirects() {
+    return [
+      {
+        source: '/:path((?!trees).*)',
+        has: [
+          {
+            type: 'query',
+            key: 'treeid',
+            value: '(?<treeId>(\\d{1,}))',
+          },
+        ],
+        destination: '/trees/:treeId(\\d{1,})',
+        permanent: true,
+      },
+      {
+        source: '/:path((?!planters).*)',
+        has: [
+          {
+            type: 'query',
+            key: 'userid',
+            value: '(?<planterId>(\\d{1,}))',
+          },
+        ],
+        destination: '/planters/:planterId(\\d{1,})',
+        permanent: true,
       },
     ];
   },


### PR DESCRIPTION
# Description

Uses 308 redirect instead of 301, but these are basically same thing. If anything, 308 is slightly better. Only did this as its out of the box with next.js https://nextjs.org/docs/api-reference/next.config.js/redirects

redirects allow and URL the has the query treeid or userid to redirect, e.g. /foo/bar?treeid=123 redirects to /trees/123?treeid=123 (will not redirect if path contains 'trees' or 'planters' to prevent infinite redirect loop)

next.js also preserves url path by default, kind of annoying but wont hurt anything i cant image. 

also cleaned up other path var names in rewrites, only to keep things consistent. opted for camelCase

Fixes #740

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots


# How Has This Been Tested?

- [x] Cypress integration
- [x] Cypress component tests
- [x] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
