### PR TITLE
feat(playground): can preview on mobile/desktop

### DIFF
--- a/src/pages/admin/theme.js
+++ b/src/pages/admin/theme.js
@@ -1,5 +1,7 @@
 import AutoRenewIcon from '@mui/icons-material/Autorenew';
+import ComputerIcon from '@mui/icons-material/Computer';
 import FontDownloadIcon from '@mui/icons-material/FontDownload';
+import MobileFriendlyIcon from '@mui/icons-material/MobileFriendly';
 import PaletteIcon from '@mui/icons-material/Palette';
 import PreviewIcon from '@mui/icons-material/Preview';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
@@ -41,6 +43,7 @@ function ThemeConfig() {
   const [themeType, setThemeType] = usePlaygroundThemeType();
   const { resetTheme } = usePlaygroundUtils();
   const [autoReload, setAutoReload] = useState(false);
+  const [viewMobile, setViewMobile] = useState(false);
 
   const [tabIndex, setTabIndex] = useState(0);
   const handleTabChange = (_, newIndex) => {
@@ -386,14 +389,23 @@ function ThemeConfig() {
         height: '100vh',
       }}
     >
-      <Grid item xs={9}>
+      <Grid
+        item
+        xs={9}
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
         <iframe
           ref={iframeRef}
+          key={viewMobile}
           title="sandbox"
           src="http://localhost:3000/top"
           style={{
-            width: '100%',
-            height: '100%',
+            height: viewMobile ? '740px' : '100%',
+            width: viewMobile ? '360px' : '100%',
             border: 'none',
           }}
         />
@@ -417,6 +429,11 @@ function ThemeConfig() {
             icon={<PreviewIcon />}
             tooltip="Reload Preview"
             onClick={handlePreview}
+          />
+          <SquareIconButton
+            icon={viewMobile ? <ComputerIcon /> : <MobileFriendlyIcon />}
+            tooltip={`Toggle ${viewMobile ? 'Desktop' : 'Mobile'}`}
+            onClick={() => setViewMobile((prev) => !prev)}
           />
           <Button onClick={handleSave}>save</Button>
           <Button onClick={handleLoad}>load</Button>


### PR DESCRIPTION
# Description
Toggle for preview on Mobile and Desktop

Fixes #668

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
Mobile Preview (Desktop did not change)
![image](https://user-images.githubusercontent.com/31519867/183378538-8d0163fd-4d36-4ec8-ab83-f8afe879593b.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
