### PR TITLE
fix: icon no dark mode support

### DIFF
--- a/src/components/ImpactSection.js
+++ b/src/components/ImpactSection.js
@@ -43,7 +43,13 @@ function ImpactSection() {
           <CustomCard
             handleClick={() => setIsPlanterTab(false)}
             iconURI={CarbonIcon}
-            sx={{ width: 26, height: 34 }}
+            sx={{
+              width: 26,
+              height: 34,
+              '& path': {
+                stroke: ({ palette }) => palette.text.primary,
+              },
+            }}
             title="Carbon Capture"
             text="---"
             disabled={isPlanterTab}


### PR DESCRIPTION
# Description
Fixes icon color in dark mode

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Before|After
:-:|:-:
![image](https://user-images.githubusercontent.com/31519867/184091471-993a07cc-5435-4764-98d2-0845a9487a7e.png)|![image](https://user-images.githubusercontent.com/31519867/184091558-05bfe9e6-3e52-4319-84cc-7ce5a5a58af3.png)




# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings