### PR TITLE
fix: drawer expand icon color

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,6 +1,5 @@
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { Box, Paper } from '@mui/material';
-import * as d3 from 'd3';
 import log from 'loglevel';
 import React from 'react';
 
@@ -216,11 +215,7 @@ export default function Drawer(props) {
             sx={{
               height: 42,
               width: 42,
-              color: (t) =>
-                d3
-                  .color(t.palette.greyLight.main)
-                  .copy({ opacity: 0.7 })
-                  .formatRgb(),
+              color: (t) => t.palette.text.disabled,
             }}
           />
           <Box


### PR DESCRIPTION
# Description
Fixes drawer expand icon color contrast

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Before|After
:-:|:-:|
![localhost_3000_planters_5449(Samsung Galaxy S8+)](https://user-images.githubusercontent.com/31519867/184360738-48668849-2205-445c-a5df-b959cbe9a5bb.png)|![localhost_3000_planters_5449(Samsung Galaxy S8+) (2)](https://user-images.githubusercontent.com/31519867/184360840-0d27e461-3e90-4bdf-805e-1c2db3eaafc2.png)

[comment]: # 'Please include screenshots of your changes if relevant.'

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
