### PR TITLE
feat: disable cards on impact section

### DIFF
--- a/src/components/ImpactSection.js
+++ b/src/components/ImpactSection.js
@@ -6,8 +6,6 @@ import DollarIcon from '../images/icons/dollar.svg';
 import StaticGraph from '../images/static-graph.svg';
 
 function ImpactSection() {
-  const [isPlanterTab, setIsPlanterTab] = useState(true);
-
   return (
     <>
       <Typography
@@ -31,17 +29,17 @@ function ImpactSection() {
       >
         <Grid item sx={{ width: '49%' }}>
           <CustomCard
-            handleClick={() => setIsPlanterTab(true)}
+            handleClick={() => {}}
             iconURI={DollarIcon}
             sx={{ width: 26, height: 34 }}
             title="Current Value"
             text="---"
-            disabled={!isPlanterTab}
+            disabled
           />
         </Grid>
         <Grid item sx={{ width: '49%' }}>
           <CustomCard
-            handleClick={() => setIsPlanterTab(false)}
+            handleClick={() => {}}
             iconURI={CarbonIcon}
             sx={{
               width: 26,
@@ -52,7 +50,7 @@ function ImpactSection() {
             }}
             title="Carbon Capture"
             text="---"
-            disabled={isPlanterTab}
+            disabled
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
# Description
Disables the custom cards on the impact section as described in the issue

Fixes #787

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
![image](https://user-images.githubusercontent.com/31519867/185059834-be7134ee-efa6-4621-8d95-cb974eafaa82.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
