### PR TITLE
fix: leaderboard fetch on continent

### DIFF
--- a/src/pages/top.js
+++ b/src/pages/top.js
@@ -38,6 +38,8 @@ function Top({ trees, planters, countries, organizations }) {
     React.useState(countries);
 
   React.useEffect(() => {
+    if (process.env.NEXT_PUBLIC_COUNTRY_LEADER_BOARD_DISABLED === 'true')
+      return;
     const fetchCountries = async () => {
       const data = await utils.requestAPI(
         `/countries/leaderboard?continent=${continentTag}`,


### PR DESCRIPTION
# Description
Fixes error that occurs on fetching the leaderboard when the continent state changes

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
