### PR TITLE
refactor: re-usable LikeButton

### DIFF
--- a/src/components/LikeButton.js
+++ b/src/components/LikeButton.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-function LikeButton({ treeId }) {
+function LikeButton({ url }) {
   const loadScript = () =>
     new Promise((resolve, reject) => {
       const loaded = document.getElementById('fbsdk');
@@ -29,7 +29,7 @@ function LikeButton({ treeId }) {
   return (
     <div
       className="fb-like"
-      data-href={`https://map.treetracker.org/trees/${treeId}`}
+      data-href={url}
       data-width=""
       data-layout="box_count"
       data-action="like"

--- a/src/components/common/CustomImageWrapper.js
+++ b/src/components/common/CustomImageWrapper.js
@@ -146,7 +146,7 @@ function CustomImageWrapper({ imageUrl, timeCreated, treeId }) {
           width="100%"
           height="100%"
         >
-          <LikeButton treeId={treeId} />
+          <LikeButton url={`https://map.treetracker.org/trees/${treeId}`} />
         </Grid>
       </InfoWrapper>
       <img src={imageUrl} alt="tree" className={classes.image} />

--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -474,7 +474,7 @@ export default function Tree({
             justifyContent: 'space-between',
           }}
         >
-          <LikeButton treeId={tree.id} />
+          <LikeButton url={`https://map.treetracker.org/trees/${tree.id}`} />
           <Box
             sx={{
               display: 'flex',


### PR DESCRIPTION
Replace treeId prop with full url prop

# Description
Small change to the LikeButton component prop.

Fixes #824 

## Type of change

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
