### PR TITLE
fix: impact section icon heights

### DIFF
--- a/src/components/ImpactSection.js
+++ b/src/components/ImpactSection.js
@@ -31,7 +31,7 @@ function ImpactSection() {
           <CustomCard
             handleClick={() => {}}
             iconURI={DollarIcon}
-            sx={{ width: 26, height: 34 }}
+            sx={{ width: [24, 32], height: [24, 32] }}
             title="Current Value"
             text="---"
             disabled
@@ -42,8 +42,8 @@ function ImpactSection() {
             handleClick={() => {}}
             iconURI={CarbonIcon}
             sx={{
-              width: 26,
-              height: 34,
+              width: [24, 32],
+              height: [24, 32],
               '& path': {
                 stroke: ({ palette }) => palette.text.primary,
               },


### PR DESCRIPTION
# Description

Changed the height of the icons to be responsive
Fixes #785

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Desktop
|Before
|:-:
|![localhost_3000_trees_186735_embed=false (1)](https://user-images.githubusercontent.com/31519867/185622383-dabee6f6-3c95-4d4c-b6d6-fb29080e282a.png)
|After
|![localhost_3000_trees_186735_embed=false](https://user-images.githubusercontent.com/31519867/185621507-69e33cb1-e96a-4bdc-86fe-cd8968c09367.png)


Mobile
Before|After
:-:|:-:
![localhost_3000_trees_186735_embed=false(Samsung Galaxy S8+) (1)](https://user-images.githubusercontent.com/31519867/185621347-14d98244-c7d9-471a-99f5-bef53cde177a.png)|![localhost_3000_trees_186735_embed=false(Samsung Galaxy S8+) (2)](https://user-images.githubusercontent.com/31519867/185622170-d1afae04-e5c5-4de7-8c0f-7257c5bd6468.png)





# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
