### PR TITLE
ISR/Cache for /top

### DIFF
--- a/src/components/FeaturedPlantersSlider/index.js
+++ b/src/components/FeaturedPlantersSlider/index.js
@@ -130,7 +130,9 @@ function FeaturedPlantersSlider({
               >
                 <CardMedia
                   component="img"
-                  image={planter.logo_url || planter.image_url}
+                  image={
+                    planter.logo_url || planter.image_url || planter.photo_url
+                  }
                   alt="tree"
                   sx={{
                     width: 136,

--- a/src/pages/top.js
+++ b/src/pages/top.js
@@ -222,7 +222,6 @@ export async function getStaticProps() {
       organizations,
     },
     revalidate: 60,
-    fallback: 'blocking',
   };
 }
 

--- a/src/pages/top.js
+++ b/src/pages/top.js
@@ -197,21 +197,21 @@ function Top({ trees, planters, countries, organizations }) {
   );
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const [trees, countries, planters, organizations] = await Promise.all([
-    getFeaturedTrees(), //
+    getFeaturedTrees(),
     process.env.NEXT_PUBLIC_COUNTRY_LEADER_BOARD_DISABLED === 'true'
       ? []
       : getCountryLeaderboard(),
     (async () => {
       const data = await utils.requestAPI('/planters/featured');
       log.warn('planters', data);
-      return data.planters;
+      return [data];
     })(),
     (async () => {
       const data = await utils.requestAPI('/organizations/featured');
       log.warn('organizations', data);
-      return data.organizations;
+      return [data];
     })(),
   ]);
   return {
@@ -221,6 +221,8 @@ export async function getServerSideProps() {
       planters,
       organizations,
     },
+    revalidate: 60,
+    fallback: 'blocking',
   };
 }
 


### PR DESCRIPTION
# Description

Using ISR for /top, pre-renders /top at build time
Also hot fix for undefined planter image call

for ISR:
- does not run at development build time, only production
- in development, /top is rebuilt on each request
- in production, /top is rebuilt on next call after successful re-render, no more than every 60 seconds (time is flexible obviously)

Fixes #797

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Cypress integration
- [x] Cypress component tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
