### PR TITLE
fix: impact section icon colors

### DIFF
--- a/src/components/ImpactSection.js
+++ b/src/components/ImpactSection.js
@@ -31,7 +31,14 @@ function ImpactSection() {
           <CustomCard
             handleClick={() => {}}
             iconURI={DollarIcon}
-            sx={{ width: 26, height: 34 }}
+            sx={{
+              width: 26,
+              height: 34,
+              '& path': {
+                stroke: ({ palette }) => palette.text.disabled,
+                fill: ({ palette }) => palette.text.disabled,
+              },
+            }}
             title="Current Value"
             text="---"
             disabled
@@ -45,7 +52,7 @@ function ImpactSection() {
               width: 26,
               height: 34,
               '& path': {
-                stroke: ({ palette }) => palette.text.primary,
+                stroke: ({ palette }) => palette.text.disabled,
               },
             }}
             title="Carbon Capture"


### PR DESCRIPTION
# Description
Changed the icon colors to be disabled
Fixes #828 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
![image](https://user-images.githubusercontent.com/31519867/185735914-c952ca34-b50b-413c-9d90-cb78dd371d28.png)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
