### PR TITLE
fix: isr usage of msw

### DIFF
--- a/doc/examples/planters/940.json
+++ b/doc/examples/planters/940.json
@@ -2,7 +2,7 @@
   "id": 940,
   "first_name": "Sebastian ",
   "last_name": "Gaertner",
-  "photo_url": "https://treetracker-dev-images.s3.eu-central-1.amazonaws.com/2020.10.19.09.47.53_-5.508107173727935_38.981361706266256_39f0cc9d-0f13-4547-8142-150f15cabb67_IMG_20201019_094513_6614320100195503436.jpg",
+  "image_url": "https://treetracker-dev-images.s3.eu-central-1.amazonaws.com/2020.10.19.09.47.53_-5.508107173727935_38.981361706266256_39f0cc9d-0f13-4547-8142-150f15cabb67_IMG_20201019_094513_6614320100195503436.jpg",
   "trees_planted": 4,
   "about": "Greenway is a Youth-Driven Environmental Protection Organization providing alternative solutions to single-use plastic and planting carbon-sucking trees for socio-economic development and reducing climate crisis. Our social work includes reforestation, landscape restoration, climate education, awareness campaign, conducting research, outreach activities, and collaborating with key stakeholders to implement sustainable solutions.",
   "mission": "To combat climate change, desertification, land degradation, carbon emission by inspiring healthier communities affected by severe climate disorder and modestly reducing pollution by 2050.",

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -20,11 +20,7 @@ const handlers = [
   rest.get(`${host}/trees*`, (req, res, ctx) =>
     res(ctx.status(200, 'success'), ctx.json(trees)),
   ),
-
-  rest.get(`${host}/planters/:id`, (req, res, ctx) =>
-    res(ctx.status(200, 'success'), ctx.json(planter)),
-  ),
-  rest.get(`${host}/planters*`, (req, res, ctx) =>
+  rest.get(`${host}/planters/featured`, (req, res, ctx) =>
     res(
       ctx.status(200, 'success'),
       ctx.json({
@@ -33,16 +29,19 @@ const handlers = [
     ),
   ),
 
-  rest.get(`${host}/organizations/:id`, (req, res, ctx) =>
-    res(ctx.status(200, 'success'), ctx.json(organization)),
+  rest.get(`${host}/planters/:id`, (req, res, ctx) =>
+    res(ctx.status(200, 'success'), ctx.json(planter)),
   ),
-  rest.get(`${host}/organizations*`, (req, res, ctx) =>
+  rest.get(`${host}/organizations/featured`, (req, res, ctx) =>
     res(
       ctx.status(200, 'success'),
       ctx.json({
-        organizations: [organization, organization],
+        organizations: [organization, organization, organization],
       }),
     ),
+  ),
+  rest.get(`${host}/organizations/:id`, (req, res, ctx) =>
+    res(ctx.status(200, 'success'), ctx.json(organization)),
   ),
 
   rest.get(`${host}/species*`, (req, res, ctx) =>

--- a/src/pages/top.js
+++ b/src/pages/top.js
@@ -197,7 +197,7 @@ function Top({ trees, planters, countries, organizations }) {
   );
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const [trees, countries, planters, organizations] = await Promise.all([
     getFeaturedTrees(), //
     process.env.NEXT_PUBLIC_COUNTRY_LEADER_BOARD_DISABLED === 'true'
@@ -221,6 +221,7 @@ export async function getServerSideProps() {
       planters,
       organizations,
     },
+    revalidate: 60,
   };
 }
 


### PR DESCRIPTION
# Description

Related to my previous PR for using ISR on the /top page

Basically issue was in dev env, we are using MSW. MSW handlers were designed incorrectly resulting in them returning a single planter/org object when requesting /planters/featured or /organizations/featured (was picking up featured as the ID). However, prod api returns object with an array of planters/orgs inside of it.

In my last PR, I was relying on MSW data to make change that returned [data] instead of data.planters or data.organizations (since mock data returned an object and we were expecting an array).

To fix this, I updated MSW to return data matching that of the prod api and updated the /top ISR usage so we can take advantage of caching. This also involved updating the image key name for the planters.

Fixes #857

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Cypress integration
- [x] Cypress component tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
