### PR TITLE
fix: removed sx prop from CustomeCard.js

### DIFF
--- a/src/components/common/CustomCard.cy.js
+++ b/src/components/common/CustomCard.cy.js
@@ -1,8 +1,21 @@
 import CustomCard from './CustomCard';
+import TreeIcon from '../../images/icons/tree.svg';
 import { mountWithTheme as mount } from '../../models/test-utils';
 
 describe('mount Card', () => {
   it('CustomCard', () => {
-    mount(<CustomCard />);
+    const props = {
+      iconURI: TreeIcon,
+      title: 'Trees',
+      text: '12',
+      disabled: false,
+    };
+
+    mount(<CustomCard {...props} />);
+
+    cy.viewport(390, 844);
+    cy.screenshot();
+    cy.viewport(1440, 800);
+    cy.screenshot();
   });
 });

--- a/src/components/common/CustomCard.cy.js
+++ b/src/components/common/CustomCard.cy.js
@@ -1,17 +1,72 @@
 import CustomCard from './CustomCard';
+import CarbonIcon from '../../images/icons/carbon.svg';
+import DollarIcon from '../../images/icons/dollar.svg';
+import TokenIcon from '../../images/icons/token.svg';
 import TreeIcon from '../../images/icons/tree.svg';
 import { mountWithTheme as mount } from '../../models/test-utils';
 
 describe('mount Card', () => {
   it('CustomCard', () => {
-    const props = {
+    /* We simulate the props to be close to the real app */
+    const propsTrees = {
       iconURI: TreeIcon,
       title: 'Trees',
       text: '12',
       disabled: false,
+      sx: {
+        height: 34,
+        width: 26,
+      },
     };
 
-    mount(<CustomCard {...props} />);
+    const propsTokens = {
+      iconURI: TokenIcon,
+      title: 'Tokens',
+      text: '12',
+      disabled: false,
+      sx: {
+        height: 36,
+        width: 36,
+      },
+    };
+
+    const propsCurrentValue = {
+      iconURI: DollarIcon,
+      title: 'Current Value',
+      text: '---',
+      disabled: false,
+      sx: {
+        height: [24, 32],
+        width: [24, 32],
+        '& path': {
+          stroke: 'rgb(107, 110, 112)',
+          fill: 'rgb(107, 110, 112)',
+        },
+      },
+    };
+
+    const propsCarbonCapture = {
+      iconURI: CarbonIcon,
+      title: 'Carbon Capture',
+      text: '---',
+      disabled: false,
+      sx: {
+        height: [24, 32],
+        width: [24, 32],
+        '& path': {
+          stroke: 'rgb(107, 110, 112)',
+        },
+      },
+    };
+
+    mount(
+      <div>
+        <CustomCard {...propsTrees} />
+        <CustomCard {...propsTokens} />
+        <CustomCard {...propsCurrentValue} />
+        <CustomCard {...propsCarbonCapture} />
+      </div>,
+    );
 
     cy.viewport(390, 844);
     cy.screenshot();

--- a/src/components/common/CustomCard.js
+++ b/src/components/common/CustomCard.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles()((theme) => ({}));
 function CustomCard(props) {
   const { classes } = useStyles(props);
   const theme = useTheme();
-  const { iconURI, title, text, handleClick, disabled, tooltip } = props;
+  const { iconURI, title, text, handleClick, disabled, tooltip, sx } = props;
 
   return (
     <Box
@@ -46,6 +46,7 @@ function CustomCard(props) {
         >
           <SvgIcon
             sx={{
+              ...sx,
               height: [32, 52],
               width: [32, 52],
               fill: 'none',

--- a/src/components/common/CustomCard.js
+++ b/src/components/common/CustomCard.js
@@ -46,9 +46,9 @@ function CustomCard(props) {
         >
           <SvgIcon
             sx={{
-              ...sx,
               height: [32, 52],
               width: [32, 52],
+              ...sx,
               fill: 'none',
             }}
             component={iconURI}

--- a/src/components/common/CustomCard.js
+++ b/src/components/common/CustomCard.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles()((theme) => ({}));
 function CustomCard(props) {
   const { classes } = useStyles(props);
   const theme = useTheme();
-  const { iconURI, title, text, handleClick, disabled, tooltip, sx } = props;
+  const { iconURI, title, text, handleClick, disabled, tooltip } = props;
 
   return (
     <Box
@@ -46,7 +46,8 @@ function CustomCard(props) {
         >
           <SvgIcon
             sx={{
-              ...sx,
+              height: [32, 52],
+              width: [32, 52],
               fill: 'none',
             }}
             component={iconURI}


### PR DESCRIPTION
# Description

[comment]: # 'resolves #843 The SvgIcon in CustomCard.js no longer uses the sx prop being passed in and instead is fixed to 32px for breakpoint below sm and 52px for breakpoint above sm. Senior devs suggested the change in the issue description https://github.com/Greenstand/treetracker-web-map-client/issues/843'

Fixes #843

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![mount Card -- CustomCard (1)](https://user-images.githubusercontent.com/97291663/186855361-413377f6-9b8a-4cc6-9296-39dfbab3f9ff.png)
![mount Card -- CustomCard](https://user-images.githubusercontent.com/97291663/186855369-802eed64-0541-4050-adfd-343e5f8b4e59.png)

[comment]: # 'Please include screenshots of your changes if relevant.'

# How Has This Been Tested?

- [x] Cypress component tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
