### PR TITLE
fix: react sx prop warning

### DIFF
--- a/src/components/LeaderBoard.js
+++ b/src/components/LeaderBoard.js
@@ -94,11 +94,10 @@ function TreeImage(isMobile) {
     <SvgIcon
       component={TreeIcon}
       inheritViewBox
-      sx={`${
-        !isMobile
-          ? 'width: 13.5px; height: 18px;'
-          : 'width: 12px; height: 14px;'
-      }`}
+      sx={{
+        width: !isMobile ? '13.5px' : '12px',
+        height: !isMobile ? '18px' : '14px',
+      }}
       alt="tree icon"
     />
   );


### PR DESCRIPTION
# Description

Fixes warning caused by passing an invalid value to `sx` prop

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
