### PR TITLE
fix: drawer title not clickable

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -168,6 +168,9 @@ export default function Drawer(props) {
     buttonRef.current.addEventListener('touchend', handleButtonTouchEnd);
     contentRef.current.addEventListener('touchmove', handleContentTouchMove);
 
+    // click handlers
+    buttonRef.current.addEventListener('click', handleOpen);
+
     // contentRef.current.addEventListener("touchstart", e => { e.stopPropagation(); }, { passive: false })
     // contentRef.current.addEventListener("touchmove", e => { e.stopPropagation(); }, { passive: false })
     // contentRef.current.addEventListener("touchend", e => { e.stopPropagation(); }, { passive: false })
@@ -189,6 +192,9 @@ export default function Drawer(props) {
         'touchmove',
         handleContentTouchMove,
       );
+
+      // click handlers
+      buttonRef.current.removeEventListener('click', handleOpen);
       // contentRef.current.removeEventListener("touchstart");
       // contentRef.current.addEventListener("touchmove");
       // contentRef.current.addEventListener("touchend");
@@ -246,7 +252,6 @@ export default function Drawer(props) {
               pl: '10px',
             }}
             id="drawer-title-container-min"
-            onClick={handleOpen}
           />
         </Box>
       </Paper>


### PR DESCRIPTION
# Description
Remove the `onClick`
Add click event listener

Fixes #863

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
