### PR TITLE
fix: mobile app height incorrect

### DIFF
--- a/src/components/LayoutMobile.js
+++ b/src/components/LayoutMobile.js
@@ -14,7 +14,6 @@ const Drawer = dynamic(() => import('./Drawer'), { ssr: false });
 
 const useStyles = makeStyles()((theme) => ({
   root: {
-    height: '100vh',
     display: 'flex',
     flexDirection: 'column',
   },
@@ -61,7 +60,12 @@ export default function Layout({ children }) {
   }
 
   return (
-    <Box className={classes.root}>
+    <Box
+      className={classes.root}
+      sx={{
+        height: () => `${window.innerHeight  }px`,
+      }}
+    >
       <Navbar />
       <Box sx={{ position: 'relative', width: 1, height: 1 }}>
         <Box


### PR DESCRIPTION
# Description
Change height to window innerheight

Fixes #867

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Physical Device | Chrome Simulator
:-:|:-:
![Screenshot_20220904-143349_Chrome](https://user-images.githubusercontent.com/31519867/188313721-93719f7e-8b63-4a43-b4f0-2dde8f7f0953.jpg)|![image](https://user-images.githubusercontent.com/31519867/188313731-3884a6a2-fa29-4b91-b48b-92cfa1bd1c0a.png)


[comment]: # 'Please include screenshots of your changes if relevant.'

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
