### PR TITLE
fix: timeline dark theme color incorrect

### DIFF
--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -163,7 +163,13 @@ function Timeline() {
                   }
                   label="Start"
                 />
-                <Typography>to</Typography>
+                <Typography
+                  sx={{
+                    color: 'text.primary',
+                  }}
+                >
+                  to
+                </Typography>
                 <MobileDatePicker
                   value={timeFrame.end}
                   onChange={(newValue) =>


### PR DESCRIPTION
# Description
Fixes dark theme text color incorrect

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Before|After
:-:|:-:
![image](https://user-images.githubusercontent.com/31519867/188425538-8c9014b8-1bdc-4826-85f3-51e661b9616b.png)|![image](https://user-images.githubusercontent.com/31519867/188425412-e90485c8-babf-4377-ad76-01d7e7686391.png)


[comment]: # 'Please include screenshots of your changes if relevant.'


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings