### PR TITLE
workflow updates and cypress home component unit test timeout

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       # https://github.com/actions/checkout
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # only install dependencies
       # https://github.com/cypress-io/github-action
       - name: Install 📦
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           runTests: false
 
@@ -31,11 +31,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Install cached NPM dependencies, run integration tests
       - name: Cypress Integration Tests 🧪
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           # use mock api
           env: nock=true
@@ -45,13 +45,13 @@ jobs:
       - name: Save screenshots
         # step runs even if other steps fail
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cypress-screenshots
           path: cypress/screenshots
       - name: Save videos
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cypress-videos
           path: cypress/videos
@@ -63,10 +63,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Component tests 🧪
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           command: npx cypress run-ct
 
@@ -79,14 +79,14 @@ jobs:
       - name: Save screenshots
         # step runs even if other steps fail
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cypress-screenshots-ct
           path: cypress/screenshots
 
       - name: Save videos
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: cypress-videos-ct
           path: cypress/videos

--- a/cypress/tests/integration/index.cy.js
+++ b/cypress/tests/integration/index.cy.js
@@ -1,4 +1,4 @@
-describe('home', () => {
+describe('home', { defaultCommandTimeout: 5000 }, () => {
   it('home page', () => {
     cy.visit('/');
     cy.contains('Come explore the global reforestation effort');


### PR DESCRIPTION
# Description

- feat: updates actions/checkout@v2 to actions/checkout@v3, actions/upload-artifact@v2 to actions/upload-artifact@v3 and cypress-io/github-action@v2 to cypress-io/github-action@v4
- fix: increases home component unit test timeout because it sometimes fail due to longer load time of home page

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

# How Has This Been Tested?

- [x] Cypress integration
- [x] Cypress component tests
- [x] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
