### PR TITLE
fix: custom card icon colors

### DIFF
--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -315,7 +315,13 @@ export default function Organization(props) {
               <CustomCard
                 handleClick={() => setIsPlanterTab(true)}
                 iconURI={TreeIcon}
-                sx={{ width: 26, height: 34 }}
+                sx={{
+                  width: 26,
+                  height: 34,
+                  '& path': {
+                    fill: ({ palette }) => palette.primary.main,
+                  },
+                }}
                 title="Trees Planted"
                 text={organization?.featuredTrees?.trees.length || '---'}
                 disabled={!isPlanterTab}
@@ -325,7 +331,13 @@ export default function Organization(props) {
               <CustomCard
                 handleClick={() => setIsPlanterTab(false)}
                 iconURI={PeopleIcon}
-                sx={{ height: 36, width: 36 }}
+                sx={{
+                  height: 36,
+                  width: 36,
+                  '& path': {
+                    fill: ({ palette }) => palette.text.primary,
+                  },
+                }}
                 title="Hired Planters"
                 text={
                   organization?.associatedPlanters?.planters.length || '---'

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -326,7 +326,13 @@ export default function Planter(props) {
             <CustomCard
               handleClick={() => setIsPlanterTab(true)}
               iconURI={TreeIcon}
-              sx={{ height: 34, width: 26 }}
+              sx={{
+                height: 34,
+                width: 26,
+                '& path': {
+                  fill: ({ palette }) => palette.primary.main,
+                },
+              }}
               title="Trees Planted"
               text={treeCount}
               disabled={!isPlanterTab}
@@ -340,7 +346,13 @@ export default function Planter(props) {
                   : undefined
               }
               iconURI={PeopleIcon}
-              sx={{ height: 36, width: 36 }}
+              sx={{
+                height: 36,
+                width: 36,
+                '& path': {
+                  fill: ({ palette }) => palette.text.primary,
+                },
+              }}
               title="Ass. Orgs"
               text={
                 planter.associatedOrganizations.organizations.length || (

--- a/src/pages/wallets/[walletid].js
+++ b/src/pages/wallets/[walletid].js
@@ -228,7 +228,13 @@ export default function Wallet(props) {
           <CustomCard
             handleClick={() => setIsTokenTab(false)}
             iconURI={TreeIcon}
-            sx={{ width: 26, height: 34 }}
+            sx={{
+              width: 26,
+              height: 34,
+              '& path': {
+                fill: ({ palette }) => palette.primary.main,
+              },
+            }}
             title="Trees"
             text={tokens.total}
             disabled={isTokenTab}
@@ -238,7 +244,13 @@ export default function Wallet(props) {
           <CustomCard
             handleClick={() => setIsTokenTab(true)}
             iconURI={TokenIcon}
-            sx={{ height: 36, width: 36 }}
+            sx={{
+              height: 36,
+              width: 36,
+              '& path': {
+                fill: ({ palette }) => palette.text.primary,
+              },
+            }}
             title="Tokens"
             text={tokens.total}
             disabled={!isTokenTab}


### PR DESCRIPTION
# Description
Fixes icon color not working in dark mode
Change the green to Greenstand primary color

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

|Dark|
|:-:|
|Before|
|![image](https://user-images.githubusercontent.com/31519867/188603787-39c5c5d6-f2bf-40f1-b7be-a9ad5351b06c.png)|
|![image](https://user-images.githubusercontent.com/31519867/188603249-dc053fed-4a8b-4888-9fca-9deaea1a21e4.png)|
|After|


|Light|
|:-:|
|Before|
|![image](https://user-images.githubusercontent.com/31519867/188603685-5a6323e5-7a14-4e7f-a090-7fd66be42158.png)|
|![image](https://user-images.githubusercontent.com/31519867/188603479-1072c872-f0a2-429c-a5e2-e9d0724f1875.png)|
|After|


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
