### PR TITLE
issue917

### DIFF
--- a/src/models/pathResolver.js
+++ b/src/models/pathResolver.js
@@ -12,7 +12,7 @@ const MAP_URL_PATTERN =
 
 function getPathWhenClickTree(tree, pathname, query) {
   const path = pathname.match(MAP_URL_PATTERN);
-  log.warn('parsed path:', path);
+  log.warn('parsed path:', path, ' for pathname:', pathname);
 
   const optionalParams = {
     ...(query.embed && { embed: query.embed }),


### PR DESCRIPTION
- chore: not watch jest
- fix: can not click tree on org/tree page
- feat: upgrade core, select tree on planter+tree page
- fix: pathResolver support query params
- feat: tree page can handle org/planter
- feat: upgrade to 2.1.0, now every page are resonsible for render map
- chore: updgrade to core 2.1.1
- chore: planter page use new core
- chore: org page use new core
- chore: wallet page use new core
- feat: can do on pages with new core version
- chore: tree page can do planter/org
- chore: tree page loading zoom level
- feat: timeline to fit new core
- feat: upgrade to 2.2.0 core
- feat: add next base handler
- fix: test
- fix: detailed log
