### PR TITLE
issue917

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -82,11 +82,11 @@ function MapComponent() {
       router.query,
     );
 
-    // base
-    result.pathname = utils.nextPathBaseEncode(
-      result.pathname,
-      process.env.NEXT_PUBLIC_BASE,
-    );
+    // // base
+    // result.pathname = utils.nextPathBaseEncode(
+    //   result.pathname,
+    //   process.env.NEXT_PUBLIC_BASE,
+    // );
 
     if (window.location.pathname === result.pathname) {
       log.warn('do not refesh if the pathname is the same!');


### PR DESCRIPTION
- chore: not watch jest
- fix: can not click tree on org/tree page
- feat: upgrade core, select tree on planter+tree page
- fix: pathResolver support query params
- feat: tree page can handle org/planter
- feat: upgrade to 2.1.0, now every page are resonsible for render map
- chore: updgrade to core 2.1.1
- chore: planter page use new core
- chore: org page use new core
- chore: wallet page use new core
- feat: can do on pages with new core version
- chore: tree page can do planter/org
- chore: tree page loading zoom level
- feat: timeline to fit new core
- feat: upgrade to 2.2.0 core
- feat: add next base handler
- fix: test
- fix: detailed log
- fix: path base problem
