### PR TITLE
fix: Vertical center in breadcrumbs component

### DIFF
--- a/src/components/common/Crumbs.js
+++ b/src/components/common/Crumbs.js
@@ -14,11 +14,11 @@ export default function Crumbs(props) {
         aria-label="breadcrumb"
         separator={
           <Typography
-            variant="caption"
+            variant="h6"
             gutterBottom={false}
             sx={{
               display: 'flex',
-              alignItems: 'flex-end',
+              alignItems: 'center',
               minHeight: [16, 24],
             }}
           >
@@ -48,7 +48,7 @@ export default function Crumbs(props) {
                 gutterBottom={false}
                 sx={{
                   display: 'flex',
-                  alignItems: 'flex-end',
+                  alignItems: 'center',
                   minHeight: [16, 24],
                   cursor: item.url || 'text',
                 }}


### PR DESCRIPTION
# Description

The icons/images are centered vertically

Fixes #901 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

![breadcrumbs](https://gateway.ipfs.io/ipfs/QmZYabjU6pZLrPh32PuNbK7681ydnyTNSdyFkjZ2mS6zwM)

# How Has This Been Tested?

- [x] Cypress integration
- [x] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
