### PR TITLE
fix: drawer bottom not visible

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -260,10 +260,12 @@ export default function Drawer(props) {
           top: 0,
           left: 0,
           width: '100%',
-          height: '100vh',
+          height: '100%',
           transition: 'transform 125ms cubic-bezier(0, 0, 0.2, 1) 0ms',
           // transform: 'translateY(500px)',
           zIndex: '999',
+          display: 'flex',
+          flexDirection: 'column',
         }}
       >
         <Box


### PR DESCRIPTION
# Description
- Fixes drawer bottom not visible

Different approach on this commit 9fbeb59160e9ea7cd979e2d2807027a3a700f0d7
Turns out I had to change the height of the drawer root instead of the content

The big white space on the bottom is caused by [this line](https://github.com/Greenstand/treetracker-web-map-client/blob/beta/src/pages/planters/%5Bplanterid%5D.js#L455) we probably used this to "fix" the bottom problem

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Before|After
:-:|:-:
![image](https://user-images.githubusercontent.com/31519867/189521014-cc9ff17c-0665-4e74-ad20-7e95025c2716.png)|![image](https://user-images.githubusercontent.com/31519867/189521037-ac66a451-7525-40fd-afe1-0b9c8a0ef727.png)



[comment]: # 'Please include screenshots of your changes if relevant.'

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
