### PR TITLE
chore: add before/after screenshot tempate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,10 @@ Fixes # (issue)
 
 [comment]: # 'Please include screenshots of your changes if relevant.'
 
+|       Before        |       After        |
+| :-----------------: | :----------------: |
+| "screenshot before" | "screenshot after" |
+
 # How Has This Been Tested?
 
 - [ ] Cypress integration


### PR DESCRIPTION
# Description
Add before/after template for screenshots for a more efficient workflow
- Easier to compare for UI changes

## Type of change

[comment]: # 'Please delete options that are not relevant.'


- [x] New feature (non-breaking change which adds functionality)

