### PR TITLE
fix(token): token id too long in breadcrumb

### DIFF
--- a/src/pages/tokens/[tokenid].js
+++ b/src/pages/tokens/[tokenid].js
@@ -136,7 +136,11 @@ export default function Token(props) {
                   ]
                 : []),
               {
-                name: `token #${token.id}`,
+                name: (
+                  <>
+                    token #<UUIDTag uuid={token.id} />
+                  </>
+                ),
               },
             ]}
           />


### PR DESCRIPTION
# Description

Fixes #977
Add `UUIDTag` to breadcrumb

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| ![image](https://user-images.githubusercontent.com/31519867/191468665-4e30f258-2b98-4c8e-b71a-4c2ca0e60e2b.png) | ![image](https://user-images.githubusercontent.com/31519867/191468535-0b1750cb-41ad-49f0-a67c-56eb85545554.png)|


# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
