### PR TITLE
fix(planter-quote): layout not conform design

### DIFF
--- a/src/components/PlanterQuote.js
+++ b/src/components/PlanterQuote.js
@@ -70,7 +70,6 @@ function PlanterQuote(props) {
           sx={{
             display: 'flex',
             flexDirection: 'row',
-            justifyContent: 'flex-start',
             alignItems: 'center',
           }}
         >
@@ -87,6 +86,7 @@ function PlanterQuote(props) {
             sx={{
               ml: [4, 6],
               position: 'relative',
+              flex: 1,
             }}
           >
             <SvgIcon
@@ -137,13 +137,13 @@ function PlanterQuote(props) {
           sx={{
             display: 'flex',
             flexDirection: 'row',
-            justifyContent: 'flex-start',
             alignItems: 'center',
           }}
         >
           <Box
             sx={{
               position: 'relative',
+              flex: 1,
             }}
           >
             <SvgIcon


### PR DESCRIPTION
# Description
Update layout of `PlanterQuote`
See https://www.figma.com/file/XdYFdjlsHvxehlrkPVYq0l/Greenstand-Webmap?node-id=7739%3A36660

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| ![image](https://user-images.githubusercontent.com/31519867/191480036-8c16c63c-c830-4a08-a28f-72e72c34c6b0.png) | ![image](https://user-images.githubusercontent.com/31519867/191480136-7bc9ca24-91be-4aa8-8fd3-1af2b6c664bf.png) |

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
