### PR TITLE
fix(ui): make the tree info dialog full screen on mobile

### DIFF
--- a/src/components/TreeInfoDialog.js
+++ b/src/components/TreeInfoDialog.js
@@ -146,8 +146,13 @@ export default function TreeInfoDialog(props) {
         <Icon icon={MaxIcon} width={52} height={52} />
       </Box>
       <Dialog
+<<<<<<< HEAD
         fullScreen={isFullscreen}
         maxWidth={false}
+=======
+        isFullscreen={isFullscreen}
+        maxWidth={isMobile}
+>>>>>>> 332dbb4 (fix(ui): make the tree info dialog full screen on mobile)
         open={open}
         onClose={handleClose}
         scroll={isFullscreen ? 'paper' : 'body'}

--- a/src/components/TreeInfoDialog.js
+++ b/src/components/TreeInfoDialog.js
@@ -146,13 +146,8 @@ export default function TreeInfoDialog(props) {
         <Icon icon={MaxIcon} width={52} height={52} />
       </Box>
       <Dialog
-<<<<<<< HEAD
-        fullScreen={isFullscreen}
-        maxWidth={false}
-=======
         isFullscreen={isFullscreen}
         maxWidth={isMobile}
->>>>>>> 332dbb4 (fix(ui): make the tree info dialog full screen on mobile)
         open={open}
         onClose={handleClose}
         scroll={isFullscreen ? 'paper' : 'body'}


### PR DESCRIPTION
# Description

Update the display size of tree info dialog

Fixes #991 

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

The full screen display of tree info dialog happens only in mobile screens

https://user-images.githubusercontent.com/29462498/192101271-4387c702-860a-43bb-9d66-ec266b621f5f.mov


# How Has This Been Tested?

- [x] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
