### PR TITLE
fix: inconsistent height of cards

### DIFF
--- a/src/components/FeaturedTreesSlider/index.js
+++ b/src/components/FeaturedTreesSlider/index.js
@@ -94,6 +94,7 @@ function FeaturedTreesSlider({ trees, size = null, isMobile, link }) {
                 // boxShadow: '0px 2px 16px rgba(34, 38, 41, 0.15)',
                 // width: [152, 208],
                 overflow: 'initial',
+                flex: 1,
               }}
             >
               <CardMedia

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -22,7 +22,7 @@ const NextComposed = React.forwardRef((props, ref) => {
   return (
     <NextLink href={href} as={as}>
       <a
-        style={{ display: 'block' }}
+        style={{ display: 'flex' }}
         ref={ref}
         {...other}
         className={classes.link}

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -22,7 +22,7 @@ const NextComposed = React.forwardRef((props, ref) => {
   return (
     <NextLink href={href} as={as}>
       <a
-        style={{ display: 'flex' }}
+        style={{ display: 'inline-flex' }}
         ref={ref}
         {...other}
         className={classes.link}


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

Fixes #1010

**Problem**: The cards were not of the same height since the height was not defined for the cards wrapped inside the `<Link/>` component.

**Solution**: Fixed by changing the `display` property of `Link` to `flex` and adding `flex:1` to `Card` component used in FeatureTreesSlider.

_NOTE_: the changes made in `Link.js` won't affect any areas as we are wrapping a single child component inside `<Link/> `component so changing the display property from `block` to `flex` won't make any ui changes.

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

### Desktop

|       Before        |       After        |
| :-----------------: | :----------------: |
| ![192138443-058587ee-b61f-469d-9850-b8efbc9207bd](https://user-images.githubusercontent.com/68511458/192528163-149da89c-357a-4241-a1cf-b2b5bfcc77ca.png) | ![SCR-20220927-pbp](https://user-images.githubusercontent.com/68511458/192529866-ca132f7d-cac4-40c8-8848-2a30c3d5d574.jpeg)|

### Mobile 
|       Before        |       After        |
| :-----------------: | :----------------: |
| ![192138406-1de86b7d-de5f-48ed-968d-444dbf4baaaf](https://user-images.githubusercontent.com/68511458/192528197-52fb7f72-b465-4ac6-a006-2f13ad1f3a71.png) | ![SCR-20220927-pcd](https://user-images.githubusercontent.com/68511458/192530005-a5bf3cce-a7f3-460c-9acb-757cd5154640.jpeg)|

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
