### PR TITLE
fix: broken layout for longer names

### DIFF
--- a/src/components/TreeSpeciesCard.js
+++ b/src/components/TreeSpeciesCard.js
@@ -38,7 +38,6 @@ function TreeSpeciesCard(props) {
           sx={{
             wordWrap: 'break-word',
             width: '65%',
-            padding: '8px 0',
           }}
         >
           <Typography
@@ -78,7 +77,7 @@ function TreeSpeciesCard(props) {
           sx={{
             background: (t) => t.palette.background.paperDark,
             color: (t) => t.palette.text.primaryReverse,
-            padding: (t) => [t.spacing(4, 5), t.spacing(6, 8)],
+            padding: (t) => [t.spacing(5), t.spacing(6, 8)],
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',

--- a/src/components/TreeSpeciesCard.js
+++ b/src/components/TreeSpeciesCard.js
@@ -38,6 +38,7 @@ function TreeSpeciesCard(props) {
           sx={{
             wordWrap: 'break-word',
             width: '65%',
+            padding: '8px 0',
           }}
         >
           <Typography
@@ -77,7 +78,7 @@ function TreeSpeciesCard(props) {
           sx={{
             background: (t) => t.palette.background.paperDark,
             color: (t) => t.palette.text.primaryReverse,
-            padding: (t) => [t.spacing(3, 5), t.spacing(6, 8)],
+            padding: (t) => [t.spacing(4, 5), t.spacing(6, 8)],
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',

--- a/src/components/TreeSpeciesCard.js
+++ b/src/components/TreeSpeciesCard.js
@@ -32,7 +32,14 @@ function TreeSpeciesCard(props) {
         justifyContent="space-between"
         alignItems="center"
       >
-        <Grid item ml={6}>
+        <Grid
+          item
+          ml={6}
+          sx={{
+            wordWrap: 'break-word',
+            width: '65%',
+          }}
+        >
           <Typography
             variant="h5"
             sx={{

--- a/src/components/TreeSpeciesCard.js
+++ b/src/components/TreeSpeciesCard.js
@@ -77,7 +77,7 @@ function TreeSpeciesCard(props) {
           sx={{
             background: (t) => t.palette.background.paperDark,
             color: (t) => t.palette.text.primaryReverse,
-            padding: (t) => [t.spacing(5), t.spacing(6, 8)],
+            padding: (t) => [t.spacing(4.5, 6.5), t.spacing(6, 8)],
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

Fixes #992 

**Problem**: The layout for card was broken for longer names.

**Solution**: Add wordWrap and fixed width property to limit the name up to particular length and shift the rest to next line.

_NOTE: increased padding for inner card content, the height of the card is slightly increased._


## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="359" alt="191858432-41a0f344-c4d4-4c7c-8ba6-3a7e84c47e54" src="https://user-images.githubusercontent.com/68511458/192595816-0e3d708e-5cb5-4529-a725-d8147458d5cd.png">|![SCR-20220927-way](https://user-images.githubusercontent.com/68511458/192599245-ff796ca0-bd3c-44ae-a333-69d7b0e4d3bd.png)|

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
