### PR TITLE
feat: on demand revalidation route

### DIFF
--- a/src/pages/api/revalidate.js
+++ b/src/pages/api/revalidate.js
@@ -1,0 +1,17 @@
+export default async function handler({ query }, res) {
+  const { secret, path } = query;
+  if (secret !== process.env.REVALIDATION_SECRET) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  if (!path) {
+    return res.status(401).json({ message: 'Invalid path' });
+  }
+
+  try {
+    await res.revalidate(`${process.env.NEXT_PUBLIC_BASE ?? ''}${path}`);
+    return res.json({ revalidated: true });
+  } catch (err) {
+    return res.status(500).send('Error revalidating');
+  }
+}


### PR DESCRIPTION
# Description

API route for forcing revalidation of nextjs cache

User must have .env.local setup and it should contain variable REVALIDATION_SECRET, which will be supplied in api call for extra security 

Can then revalidate paths with following url (local example)
GET http://localhost:3000/web-map-beta/demo/api/revalidate?secret=TOKEN&path=/top
401 if token is bad
404 if path is bad
500 if error with revalidation function
200 if success

Will add applicable README changes in this PR, once we confirm this is built as desired

Will also add a test for this change, again once confirm its built as desired

Fixes #998 (discovery thread with @dadiorchen )

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

- [X] Cypress integration
- [X] Cypress component tests

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
