### PR TITLE
revert "fix: inconsistent height of cards"

### DIFF
--- a/src/components/FeaturedTreesSlider/index.js
+++ b/src/components/FeaturedTreesSlider/index.js
@@ -94,7 +94,6 @@ function FeaturedTreesSlider({ trees, size = null, isMobile, link }) {
                 // boxShadow: '0px 2px 16px rgba(34, 38, 41, 0.15)',
                 // width: [152, 208],
                 overflow: 'initial',
-                flex: 1,
               }}
             >
               <CardMedia

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -22,7 +22,7 @@ const NextComposed = React.forwardRef((props, ref) => {
   return (
     <NextLink href={href} as={as}>
       <a
-        style={{ display: 'inline-flex' }}
+        style={{ display: 'block' }}
         ref={ref}
         {...other}
         className={classes.link}


### PR DESCRIPTION
reverts Greenstand/treetracker-web-map-client#1015

This commit is causing problems with every link on the web map like: #1032

Should re-open #1010