### PR TITLE
feat: loading spinner

### DIFF
--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -2,9 +2,9 @@ import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import { Box, Paper } from '@mui/material';
 import log from 'loglevel';
 import React from 'react';
+import SpinnerOverlay from "./SpinnerOverlay";
 
-export default function Drawer(props) {
-  const { children } = props;
+export default function Drawer({ children, loading }) {
   const rootRef = React.useRef(null);
   const buttonRef = React.useRef(null);
   const contentRef = React.useRef(null);
@@ -158,6 +158,13 @@ export default function Drawer(props) {
     }
   }, []);
 
+  const dimensions = {
+    width: '100%',
+    height: '100vh',
+    top: 0,
+    left: 0,
+  };
+
   React.useEffect(() => {
     log.warn('mount listener...');
     rootRef.current.addEventListener('touchstart', handleTouchStart);
@@ -260,17 +267,15 @@ export default function Drawer(props) {
         elevation={10}
         className="drawer-root"
         sx={{
+          ...dimensions,
           position: 'absolute',
           borderRadius: '16px 16px 0 0 ',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100vh',
           transition: 'transform 125ms cubic-bezier(0, 0, 0.2, 1) 0ms',
           // transform: 'translateY(500px)',
           zIndex: '999',
         }}
       >
+        {loading && <SpinnerOverlay sx={{ ...dimensions, zIndex: 9999 }} />}
         <Box
           id="drawer-header"
           sx={{

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,9 +1,11 @@
 import { SvgIcon } from '@mui/material';
 import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import Paper from '@mui/material/Paper';
 import dynamic from 'next/dynamic';
 import { makeStyles } from 'models/makeStyles';
-import Timeline from "./Timeline";
+import SpinnerOverlay from "./SpinnerOverlay";
+import Timeline from './Timeline';
 import Max from '../images/max.svg';
 import ZoomIn from '../images/zoom-in.svg';
 import ZoomOut from '../images/zoom-out.svg';
@@ -53,6 +55,7 @@ export default function Layout({
   children,
   nextExtraIsEmbed,
   nextExtraIsEmbedCallback,
+  loading,
 }) {
   const mapContext = useMapContext();
   const { classes } = useStyles();
@@ -68,11 +71,14 @@ export default function Layout({
     mapContext.map.map.zoomOut();
   }
 
+  console.log('classes.left: ', classes.left);
+
   return (
     <Box className={classes.root}>
       <Navbar />
       <Box className={classes.main}>
         <Paper elevation={11} className={classes.left}>
+          {loading && <SpinnerOverlay className={classes.left} />}
           {children}
         </Paper>
         <Box className={classes.right}>

--- a/src/components/LayoutEmbed.js
+++ b/src/components/LayoutEmbed.js
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import React from 'react';
 import SearchFilter from './SearchFilter';
+import SpinnerOverlay from "./SpinnerOverlay";
 import { useEmbed } from '../hooks/globalHooks';
 import LogoIcon from '../images/greenstand_logo_full.png';
 import MinIcon from '../images/min.svg';
@@ -55,6 +56,7 @@ export default function Layout({
   nextExtraIsEmbed,
   nextExtraIsEmbedCallback,
   isFloatingDisabled,
+  loading,
 }) {
   const [isDrawerOpen, setIsDrawerOpen] = React.useState(true);
   const [toggleButtonPosition, setToggleButtonPosition] = React.useState(0);
@@ -83,6 +85,12 @@ export default function Layout({
       return 0;
     });
   }, [isDrawerOpen]);
+
+  const dimensions = {
+    width: 568,
+    height: '100vh',
+    top: '0px',
+  };
 
   return (
     <>
@@ -116,15 +124,16 @@ export default function Layout({
             <Box>
               <Box
                 sx={{
+                  ...dimensions,
                   position: 'absolute',
-                  zIndex: '99999',
-                  top: '0px',
+                  zIndex: '9999',
                   background: 'white',
-                  width: 568,
                   overflowY: 'scroll',
-                  height: '100vh',
                 }}
               >
+                {loading && (
+                  <SpinnerOverlay sx={{ ...dimensions, zIndex: 99999 }} />
+                )}
                 {children}
               </Box>
             </Box>

--- a/src/components/LayoutMobile.js
+++ b/src/components/LayoutMobile.js
@@ -48,7 +48,7 @@ const useStyles = makeStyles()((theme) => ({
   above: {},
 }));
 
-export default function Layout({ children }) {
+export default function Layout({ children, loading }) {
   const { classes } = useStyles();
   const mapContext = useMapContext();
 
@@ -69,7 +69,7 @@ export default function Layout({ children }) {
         >
           <App />
         </Box>
-        <Drawer>{children}</Drawer>
+        <Drawer loading={loading}>{children}</Drawer>
         <Box className={classes.right}>
           <Timeline />
           <Box

--- a/src/components/SpinnerOverlay.cy.js
+++ b/src/components/SpinnerOverlay.cy.js
@@ -1,0 +1,29 @@
+import Paper from '@mui/material/Paper';
+import React from 'react';
+import SpinnerOverlay from './SpinnerOverlay';
+import { mountWithTheme as mount } from '../models/test-utils';
+
+describe('SpinnerOverlay', () => {
+  it('renders', () => {
+    cy.viewport(1200, 800);
+    function Test() {
+      const [loading, setLoading] = React.useState(false);
+      const load = () => setTimeout(() => setLoading(true), '1000');
+      const dimensions = {
+        width: '100%',
+        height: '100%',
+      };
+      React.useEffect(() => load());
+      return (
+        <Paper id="container" sx={{ ...dimensions, position: 'relative' }}>
+            {loading && <SpinnerOverlay sx={dimensions} />}
+          </Paper>
+      );
+    }
+    mount(<Test />);
+    if (!cy.get('.MuiPaper-root'))
+      cy.get('MuiPaper-root', {
+        timeout: '1500',
+      }).contains('svg');
+  });
+});

--- a/src/components/SpinnerOverlay.js
+++ b/src/components/SpinnerOverlay.js
@@ -1,0 +1,20 @@
+import CircularProgress from '@mui/material/CircularProgress';
+import Paper from '@mui/material/Paper';
+
+export default function SpinnerOverlay({ className = '', sx = {} }) {
+  return (
+    <Paper
+      className={className}
+      sx={{
+        display: 'flex',
+        position: 'absolute',
+        background: 'rgba(255,255,255,.6)',
+        justifyContent: 'center',
+        alignItems: 'center',
+        ...sx,
+      }}
+    >
+      <CircularProgress />
+    </Paper>
+  );
+}

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -4,12 +4,14 @@ import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import log from 'loglevel';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 import Layout from '../components/Layout';
 import LayoutDashboard from '../components/LayoutDashboard';
 import LayoutEmbed from '../components/LayoutEmbed';
 import LayoutMobile from '../components/LayoutMobile';
 import LayoutMobileB from '../components/LayoutMobileB';
 import LayoutMobileC from '../components/LayoutMobileC';
+import SpinnerOverlay from '../components/SpinnerOverlay';
 import { DrawerProvider } from '../context/DrawerContext';
 import { CustomThemeProvider } from '../context/themeContext';
 import { useLocalStorage, useMobile, useEmbed } from '../hooks/globalHooks';
@@ -36,6 +38,7 @@ function TreetrackerApp({ Component, pageProps }) {
   const nextExtraIsDesktop = !useMobile();
   const nextExtraIsEmbed = useEmbed() === true ? true : embedLocalStorage[0];
   const nextExtraKeyword = router.query.keyword;
+  const [loading, setLoading] = useState(false);
 
   log.warn('app: isDesktop: ', nextExtraIsDesktop);
   log.warn('app: component: ', Component);
@@ -43,11 +46,31 @@ function TreetrackerApp({ Component, pageProps }) {
   log.warn('app: component: isBLayout', Component.isBLayout);
   log.warn('router:', router);
 
+  useEffect(() => {
+    const handleRouteChange = (url) =>
+      setTimeout(() => {
+        if (url !== router.asPath) {
+          setLoading(true);
+        }
+      }, '500');
+
+    router.events.on('routeChangeStart', handleRouteChange);
+    router.events.on('routeChangeComplete', () => setLoading(false));
+    router.events.on('routeChangeError', () => setLoading(false));
+
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+      router.events.off('routeChangeComplete', () => setLoading(false));
+      router.events.off('routeChangeError', () => setLoading(false));
+    };
+  });
+
   const extraProps = {
     nextExtraIsEmbed,
     nextExtraIsEmbedCallback: embedLocalStorage[1],
     nextExtraIsDesktop,
     nextExtraKeyword,
+    loading,
   };
 
   const isAdmin = !!router.asPath.match(/admin/);
@@ -78,19 +101,19 @@ function TreetrackerApp({ Component, pageProps }) {
               </LayoutEmbed>
             )}
             {!nextExtraIsDesktop && Component.isBLayout && (
-              <LayoutMobileB>
+              <LayoutMobileB loading={loading}>
                 <Component {...pageProps} {...extraProps} />
               </LayoutMobileB>
             )}
             {!nextExtraIsDesktop && Component.isCLayout && (
-              <LayoutMobileC>
+              <LayoutMobileC loading={loading}>
                 <Component {...pageProps} {...extraProps} />
               </LayoutMobileC>
             )}
             {!nextExtraIsDesktop &&
               !Component.isBLayout &&
               !Component.isCLayout && (
-                <LayoutMobile>
+                <LayoutMobile loading={loading}>
                   <Component {...pageProps} {...extraProps} />
                 </LayoutMobile>
               )}


### PR DESCRIPTION
# Description

Loading spinner for side panel/drawer on route change. chose to design in a way that it is an overlay with the previous children still underneath, visible behind semi transparent background with simple spinner in the center
At _app level trigger functions to set loading prop based on router events
At Layout levels, render new spinner overlay component if loading is true and 500ms have passed (this way it does not appear for quickly loaded content)

Fixes #1039 #976 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Screenshots

After:
![image](https://user-images.githubusercontent.com/65867719/193348442-accc8e29-e30c-45af-9ea9-e45b6fd7b1fa.png)

# How Has This Been Tested?

- [X] Cypress integration
- [X] Cypress component tests

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
