### PR TITLE
fix: featured card height inconsistent

### DIFF
--- a/src/components/FeaturedTreesSlider/index.js
+++ b/src/components/FeaturedTreesSlider/index.js
@@ -81,6 +81,9 @@ function FeaturedTreesSlider({ trees, size = null, isMobile, link }) {
           <Link
             href={link ? link(tree) : `/trees/${tree.id}`}
             key={`featured-tree-${tree.id}`}
+            style={{
+              display: 'flex',
+            }}
           >
             <Card
               elevation={8}
@@ -94,6 +97,7 @@ function FeaturedTreesSlider({ trees, size = null, isMobile, link }) {
                 // boxShadow: '0px 2px 16px rgba(34, 38, 41, 0.15)',
                 // width: [152, 208],
                 overflow: 'initial',
+                flex: 1,
               }}
             >
               <CardMedia


### PR DESCRIPTION
# Description

- add `display: flex` only on the relevant links so it does not interfere with any other links

Fixes #1010

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
|![image](https://user-images.githubusercontent.com/31519867/193462395-1c982b45-efd1-4174-8b07-99df000eac86.png)|![image](https://user-images.githubusercontent.com/31519867/193462376-57f31196-5c81-43e7-8b05-57871f881a55.png)|


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
