### PR TITLE
Feat: location for planter info on org page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,63 @@
 # [2.0.0-beta.129](https://github.com/Greenstand/treetracker-web-map-client/compare/v2.0.0-beta.128...v2.0.0-beta.129) (2022-10-08)
 
+
 ### Bug Fixes
 
-- resolve merge conflicts ([50c35c5](https://github.com/Greenstand/treetracker-web-map-client/commit/50c35c54dcd4341e187ece47eb14b396a86a55bd))
-- **ui:** make the tree info dialog full screen on mobile ([b377530](https://github.com/Greenstand/treetracker-web-map-client/commit/b3775308e5d7577bf4cd2b2cfc2cd47f5420afd3))
+* resolve merge conflicts ([50c35c5](https://github.com/Greenstand/treetracker-web-map-client/commit/50c35c54dcd4341e187ece47eb14b396a86a55bd))
+* **ui:** make the tree info dialog full screen on mobile ([b377530](https://github.com/Greenstand/treetracker-web-map-client/commit/b3775308e5d7577bf4cd2b2cfc2cd47f5420afd3))
 
 # [2.0.0-beta.128](https://github.com/Greenstand/treetracker-web-map-client/compare/v2.0.0-beta.127...v2.0.0-beta.128) (2022-10-06)
 
+
 ### Features
 
-- **utils:** add location string formatter ([657d907](https://github.com/Greenstand/treetracker-web-map-client/commit/657d907e9d8e02a9779e039884c8fe1fb4b9f256))
+* **utils:** add location string formatter ([657d907](https://github.com/Greenstand/treetracker-web-map-client/commit/657d907e9d8e02a9779e039884c8fe1fb4b9f256))
 
 # [2.0.0-beta.127](https://github.com/Greenstand/treetracker-web-map-client/compare/v2.0.0-beta.126...v2.0.0-beta.127) (2022-10-06)
 
+
 ### Bug Fixes
 
-- path resolver unit tests ([2d5be26](https://github.com/Greenstand/treetracker-web-map-client/commit/2d5be263fc4f10b5a0dc6ef86978208ba650da8f))
-- **ui:** theme dark background timeline button ([fe04e5c](https://github.com/Greenstand/treetracker-web-map-client/commit/fe04e5ccee3910fb0f1f766e514bbfa56112463a))
-- unit test path resolver ([e5941c5](https://github.com/Greenstand/treetracker-web-map-client/commit/e5941c5cac1895411ac8cb63e92677ed656ed93e))
+* path resolver unit tests ([2d5be26](https://github.com/Greenstand/treetracker-web-map-client/commit/2d5be263fc4f10b5a0dc6ef86978208ba650da8f))
+* **ui:** theme dark background timeline button ([fe04e5c](https://github.com/Greenstand/treetracker-web-map-client/commit/fe04e5ccee3910fb0f1f766e514bbfa56112463a))
+* unit test path resolver ([e5941c5](https://github.com/Greenstand/treetracker-web-map-client/commit/e5941c5cac1895411ac8cb63e92677ed656ed93e))
 
 # [2.0.0-beta.126](https://github.com/Greenstand/treetracker-web-map-client/compare/v2.0.0-beta.125...v2.0.0-beta.126) (2022-10-06)
 
+
 ### Features
 
-- add click to learn more ([66e34da](https://github.com/Greenstand/treetracker-web-map-client/commit/66e34da3081d944e60473c1119f7e5860ad9dc24))
+* add click to learn more ([66e34da](https://github.com/Greenstand/treetracker-web-map-client/commit/66e34da3081d944e60473c1119f7e5860ad9dc24))
 
 # [2.0.0-beta.125](https://github.com/Greenstand/treetracker-web-map-client/compare/v2.0.0-beta.124...v2.0.0-beta.125) (2022-10-06)
 
+
 ### Bug Fixes
 
-- **featured-card:** update spacings conform design ([b1757df](https://github.com/Greenstand/treetracker-web-map-client/commit/b1757dff692c9ff95aef80d31e90e56388a5976c))
+* **featured-card:** update spacings conform design ([b1757df](https://github.com/Greenstand/treetracker-web-map-client/commit/b1757dff692c9ff95aef80d31e90e56388a5976c))
 
 # [2.0.0-beta.124](https://github.com/Greenstand/treetracker-web-map-client/compare/v2.0.0-beta.123...v2.0.0-beta.124) (2022-10-05)
 
+
 ### Bug Fixes
 
-- bug in progress bar ([e380184](https://github.com/Greenstand/treetracker-web-map-client/commit/e3801842e5a3fee4832fb51a221f9a5156563a67))
+* bug in progress bar ([e380184](https://github.com/Greenstand/treetracker-web-map-client/commit/e3801842e5a3fee4832fb51a221f9a5156563a67))
 
 # [2.0.0-beta.123](https://github.com/Greenstand/treetracker-web-map-client/compare/v2.0.0-beta.122...v2.0.0-beta.123) (2022-10-05)
 
+
 ### Features
 
-- loading page ([5b3c1d8](https://github.com/Greenstand/treetracker-web-map-client/commit/5b3c1d8332570fe4f9dd7451944d22b4fd66264b))
-- tree as wallet background ([9b5c3c9](https://github.com/Greenstand/treetracker-web-map-client/commit/9b5c3c9c019ba368b0b478e69cdc01e59e522f90))
+* loading page ([5b3c1d8](https://github.com/Greenstand/treetracker-web-map-client/commit/5b3c1d8332570fe4f9dd7451944d22b4fd66264b))
+* tree as wallet background ([9b5c3c9](https://github.com/Greenstand/treetracker-web-map-client/commit/9b5c3c9c019ba368b0b478e69cdc01e59e522f90))
 
 # [2.0.0-beta.122](https://github.com/Greenstand/treetracker-web-map-client/compare/v2.0.0-beta.121...v2.0.0-beta.122) (2022-10-04)
 
+
 ### Features
 
-- **playground:** add color picker ([1f49e44](https://github.com/Greenstand/treetracker-web-map-client/commit/1f49e44a33450bb306fb2c0f4e5887f92b31132a))
-- **playground:** add gradient color picker ([47206d7](https://github.com/Greenstand/treetracker-web-map-client/commit/47206d7f473dcb574ef07145ce87db9c55eee158))
+* **playground:** add color picker ([1f49e44](https://github.com/Greenstand/treetracker-web-map-client/commit/1f49e44a33450bb306fb2c0f4e5887f92b31132a))
+* **playground:** add gradient color picker ([47206d7](https://github.com/Greenstand/treetracker-web-map-client/commit/47206d7f473dcb574ef07145ce87db9c55eee158))
 
 # [2.0.0-beta.121](https://github.com/Greenstand/treetracker-web-map-client/compare/v2.0.0-beta.120...v2.0.0-beta.121) (2022-10-04)
 

--- a/src/components/PlanterQuote.js
+++ b/src/components/PlanterQuote.js
@@ -11,6 +11,7 @@ import * as d3 from 'd3';
 import log from 'loglevel';
 import moment from 'moment';
 import Image from 'next/image';
+import { getLocationString } from 'models/utils';
 import Link from './Link';
 import ColorButton from './common/ColorButton';
 import DataTag from './common/DataTag';
@@ -22,7 +23,6 @@ import PeopleIcon from '../images/icons/people.svg';
 import imagePlaceholder from '../images/image-placeholder.png';
 import QuoteImgReverse from '../images/quote-reverse.svg';
 import QuoteImg from '../images/quote-symbol.svg';
-
 // TODO: something is wrong with quote-symbol.svg and quote-reverse.svg, they show a blank space. The svg files pull up as blanks. Not sure how to fix them, putting up an issue as this is something totally different than what I'm working on.
 
 function PlanterQuote(props) {
@@ -129,9 +129,10 @@ function PlanterQuote(props) {
             <Box sx={{ mt: 2 }}>
               <Info
                 iconURI={LocationIcon}
-                info={`${planter.country_name ?? 'Unkown'}, ${
-                  planter.continent_name ?? 'Unkown'
-                }`}
+                info={getLocationString(
+                  planter.country_name,
+                  planter.continent_name,
+                )}
               />
             </Box>
           </Box>
@@ -190,9 +191,7 @@ function PlanterQuote(props) {
             </Box>
             <Box sx={{ mt: 2 }}>
               info=
-              {`${planter.country_name ?? 'Unkown'}, ${
-                planter.continent_name ?? 'Unkown'
-              }`}
+              {getLocationString(planter.country_name, planter.continent_name)}
             </Box>
           </Box>
           <Avatar

--- a/src/components/PlanterQuote.js
+++ b/src/components/PlanterQuote.js
@@ -129,7 +129,9 @@ function PlanterQuote(props) {
             <Box sx={{ mt: 2 }}>
               <Info
                 iconURI={LocationIcon}
-                info={`${planter.country_name}, ${planter.continent_name}`}
+                info={`${planter.country_name ?? 'Unkown'}, ${
+                  planter.continent_name ?? 'Unkown'
+                }`}
               />
             </Box>
           </Box>
@@ -187,7 +189,10 @@ function PlanterQuote(props) {
               />
             </Box>
             <Box sx={{ mt: 2 }}>
-              <Info iconURI={LocationIcon} info="Shirimatunda, Tanzania" />
+              info=
+              {`${planter.country_name ?? 'Unkown'}, ${
+                planter.continent_name ?? 'Unkown'
+              }`}
             </Box>
           </Box>
           <Avatar

--- a/src/components/PlanterQuote.js
+++ b/src/components/PlanterQuote.js
@@ -127,7 +127,10 @@ function PlanterQuote(props) {
               />
             </Box>
             <Box sx={{ mt: 2 }}>
-              <Info iconURI={LocationIcon} info="Shirimatunda, Tanzania" />
+              <Info
+                iconURI={LocationIcon}
+                info={`${planter.country_name}, ${planter.continent_name}`}
+              />
             </Box>
           </Box>
         </Box>


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

Fixes #947

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

Not able to find planter quote in the org page to add screenshots of the changes.

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
