### PR TITLE
fix: react styles warning

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,32 +1,15 @@
 /* eslint-disable jsx-a11y/anchor-has-content */
 /* eslint-disable react/display-name */
 import MuiLink from '@mui/material/Link';
-import { makeStyles } from '@mui/styles';
 import clsx from 'clsx';
 import NextLink from 'next/link';
 import React from 'react';
 
-// generate material-ui style hook
-const useStyles = makeStyles((theme) => ({
-  link: {
-    color: theme.palette.text.primary,
-    '& :hover': {
-      color: theme.palette.text.primary,
-    },
-  },
-}));
-
 const NextComposed = React.forwardRef((props, ref) => {
   const { as, href, ...other } = props;
-  const classes = useStyles();
   return (
     <NextLink href={href} as={as}>
-      <a
-        style={{ display: 'block' }}
-        ref={ref}
-        {...other}
-        className={classes.link}
-      />
+      <a style={{ display: 'block' }} ref={ref} {...other} />
     </NextLink>
   );
 });
@@ -66,7 +49,13 @@ function LinkComponent(props) {
       className={className}
       ref={innerRef}
       href={href}
-      sx={{ textDecoration: 'none' }}
+      sx={{
+        textDecoration: 'none',
+        color: ({ palette }) => palette.text.primary,
+        '& :hover': {
+          color: ({ palette }) => palette.text.primary,
+        },
+      }}
       {...other}
     />
   );


### PR DESCRIPTION
# Description
- migrate makeStyles to `sx` prop

Fixes this warning in the breadcrumbs

```
Warning: Prop `className` did not match. Server: "makeStyles-link-8" Client: "makeStyles-link-1"
```

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
