### PR TITLE
fix(playground): textarea not updating theme values

### DIFF
--- a/src/pages/admin/theme.js
+++ b/src/pages/admin/theme.js
@@ -55,11 +55,10 @@ function ThemeConfig() {
   function handleChange(event) {
     const userValue = event.target.value;
     const parsedTheme = JSON.parse(userValue);
-    const newTheme = {
+    setTheme({
       ...theme,
-      parsedTheme,
-    };
-    setTheme(newTheme);
+      ...parsedTheme,
+    });
   }
 
   const handlePreview = useCallback(() => {


### PR DESCRIPTION
# Description
- fix: parsed theme was not using the spread operator

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
