### PR TITLE
Fix: Wallet page wrong link 

### DIFF
--- a/src/pages/wallets/[walletid].js
+++ b/src/pages/wallets/[walletid].js
@@ -227,7 +227,10 @@ export default function Wallet(props) {
         }}
       >
         <Typography variant="h4">Featured trees by {wallet.name}</Typography>
-        <FeaturedTreesSlider trees={trees} />
+        <FeaturedTreesSlider
+          trees={trees}
+          link={(item) => `/wallets/${wallet.id}/tokens/${item.token_id}`}
+        />
       </Box>
 
       <Grid


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

Fixes #1092

Passed a link prop to the FeatureTreesSlider component to redirect to the wallet link of that tree.

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
