### PR TITLE
fix(tree): make global icon consistent with others

### DIFF
--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -649,7 +649,6 @@ export default function Tree({
               sx={{
                 '& path': {
                   stroke: 'none',
-                  fill: 'pink',
                 },
               }}
             />


### PR DESCRIPTION
# Description

Fixed latitude/longitude icon color from pink to grey to make it consistent with other icons

Fixes #1101 

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="515" alt="Screenshot 2022-10-12 at 12 14 10 PM" src="https://user-images.githubusercontent.com/41188167/195275131-bdabcba5-a4ef-4e23-a4e4-e6f3d3db05ed.png"> | <img width="515" alt="Screenshot 2022-10-12 at 12 14 26 PM" src="https://user-images.githubusercontent.com/41188167/195275227-4b1ac12f-1b34-43be-b0d3-3c8bde2e437f.png"> |