### PR TITLE
Revert "feat: shorten token id"

### DIFF
--- a/src/pages/wallets/[walletid].js
+++ b/src/pages/wallets/[walletid].js
@@ -284,26 +284,17 @@ export default function Wallet(props) {
       )}
 
       <Box
-        sx={{
-          mt: [0, 16],
-          p: [2, 4],
-          display: isTokenTab ? 'flex' : 'none',
-          flexWrap: 'wrap',
-        }}
+        sx={{ mt: [0, 16], p: [2, 4], display: isTokenTab ? 'block' : 'none' }}
       >
         {tokens.tokens.map((token) => (
           <Box
             key={token.id}
             sx={{
               mt: [2, 4],
-              flex: '33.33% 0',
             }}
           >
             <TreeTag
-              TreeTagValue={`${token.id.slice(0, 4)}...${token.id.slice(
-                token.id.length - 4,
-                token.id.length,
-              )}`}
+              TreeTagValue={token.id}
               title="Token ID"
               icon={<Icon icon={TokenIcon} />}
               link={`/wallets/${wallet.id}/tokens/${token.id}`}


### PR DESCRIPTION
Reverts Greenstand/treetracker-web-map-client#1111

Have to revert it, the uuid component doesn't work on this case, hovering mouse on it can not show the complete ID 