### PR TITLE
fix: Match figma font

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -10,6 +10,9 @@ body {
   margin: 0px;
   background: #ffffff;
   overscroll-behavior: contain;
+  /* Match font weight to figma */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 .side {


### PR DESCRIPTION
# Description

Fixes #501 

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Screenshots


|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="549" alt="beforeFont" src="https://user-images.githubusercontent.com/53157755/197327746-674c1e0d-9fa9-4905-acf4-e091c753547c.png"> | <img width="572" alt="AfterFont" src="https://user-images.githubusercontent.com/53157755/197327748-ec3a15b9-5bc2-44a9-b2bf-27cc73cb8a30.png"> |


# Checklist:

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas

