### PR TITLE
fix(hooks): localstorage initial state is undefined

### DIFF
--- a/src/hooks/globalHooks/useLocalStorage.js
+++ b/src/hooks/globalHooks/useLocalStorage.js
@@ -14,7 +14,7 @@ function getStorageValue(key, defaultValue) {
 // Usage: Similar to useState. Accepts a key, value pair. For example:
 // const [mode, setMode] = useLocalStorage('theme', 'light');
 const useLocalStorage = (key, defaultValue) => {
-  const [value, setValue] = useState(undefined);
+  const [value, setValue] = useState(defaultValue);
 
   // Retrieve value from local storage on client side
   useEffect(() => {


### PR DESCRIPTION
# Description
- change initial state back to default value

Fixes issues with the theme playground and bread crumb colors

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
