### PR TITLE
fix: align cards horizontally

### DIFF
--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -474,6 +474,7 @@ export default function Organization(props) {
           </Typography>
           <Typography variant="body2" mt={7}>
             <Box
+              component="span"
               dangerouslySetInnerHTML={{
                 __html: marked.parse(organization.about || 'NO DATA YET'),
               }}
@@ -484,6 +485,7 @@ export default function Organization(props) {
           </Typography>
           <Typography variant="body2" mt={7}>
             <Box
+              component="span"
               sx={{
                 fontFamily: 'Lato',
                 fontWeight: 400,

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -473,7 +473,7 @@ export default function Planter(props) {
           variant="body2"
           className={classes.textColor}
         >
-          <div
+          <span
             dangerouslySetInnerHTML={{
               __html: marked.parse(planter.about || 'NO DATA YET'),
             }}


### PR DESCRIPTION
# Description

There was a div tag inside a p tag in multiple locations. That was breaking the layout. Changing the div to a span fixed the layout issue.

Fixes #1118

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="676" alt="before-stacked" src="https://user-images.githubusercontent.com/53157755/197720828-6ac579f8-a36f-4579-b771-97444e415ce9.png"> | <img width="691" alt="after-stacked-fix" src="https://user-images.githubusercontent.com/53157755/197720846-6a9f63af-a988-4953-aeda-c47cf9003800.png"> |

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

