### PR TITLE
fix(timeline): background color is not equal to navbar

### DIFF
--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -1,4 +1,4 @@
-import { Box, Typography, InputBase, Divider } from '@mui/material';
+import { Box, Typography, InputBase, Divider, Paper } from '@mui/material';
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
@@ -102,7 +102,8 @@ function Timeline() {
 
   return (
     isGlobalPage && (
-      <Box
+      <Paper
+        elevation={7}
         sx={{
           position: 'absolute',
           zIndex: ['996', '9999'], // 996 is same as used for zoom buttons
@@ -113,7 +114,6 @@ function Timeline() {
           pr: showPicker && '15px',
           height: 52,
           borderRadius: 4,
-          backgroundColor: 'background.paper',
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
@@ -128,7 +128,7 @@ function Timeline() {
             width: 52,
             borderRadius: 4,
             background: 'none',
-            '-webkit-tap-highlight-color': 'transparent',
+            WebkitTapHighlightColor: 'transparent',
             display: 'flex',
             justifyContent: 'center',
             alignItems: 'center',
@@ -200,7 +200,7 @@ function Timeline() {
             </Box>
           </LocalizationProvider>
         )}
-      </Box>
+      </Paper>
     )
   );
 }

--- a/src/context/themeContext.js
+++ b/src/context/themeContext.js
@@ -95,14 +95,12 @@ export function buildTheme(theMode) {
         ...(themeMode === 'light'
           ? {
               //  paper: '#fff',
-              timelineDark: '#fff',
               paperDark: '#6B6E70',
             }
           : {
               default: '#333',
               // paper: '#333',
               paper: '#4a4747',
-              timelineDark: '#615E5E',
               paperDark: '#6B6E70',
             }),
         greenGradient:


### PR DESCRIPTION
# Description

- change `Box` to `Paper` to adjust background color
- remove unused `timeline` colors in `themeContext`
- fix `kebab-case` not supported for sx properties

Fixes #895

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
|![image](https://user-images.githubusercontent.com/31519867/198826292-173067fd-9486-4206-97a3-b03b042fc2b4.png)|![image](https://user-images.githubusercontent.com/31519867/198826277-ad34ab78-d47c-4549-9c2f-112f0f6950f8.png)|



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
