### PR TITLE
fix: tagchips color not compatible custom theme

### DIFF
--- a/src/components/TagChips.js
+++ b/src/components/TagChips.js
@@ -28,7 +28,8 @@ function TagChips({ tagItems, onSelectTag }) {
             '& .MuiChip-label': {
               padding: (t) => [t.spacing(2.75, 3.5), t.spacing(3.125, 4.5)],
               typography: 'body1',
-              color: i === activeTagIdx ? 'common.white' : 'text.secondary',
+              color:
+                i === activeTagIdx ? 'primary.contrastText' : 'text.secondary',
             },
           }}
           label={tagItem}


### PR DESCRIPTION
# Description

- change text color to `primary.contrastText`

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
![localhost_3000_top_bounds=0,19 973348786110613,0,19 973348786110613 (1)](https://user-images.githubusercontent.com/31519867/198826605-4a5a0ac4-7c57-4a95-ae4f-f9e8695a1066.png)|![localhost_3000_top_bounds=0,19 973348786110613,0,19 973348786110613](https://user-images.githubusercontent.com/31519867/198826611-05caa988-2b39-4e4a-a503-82261259a1b1.png)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings