### PR TITLE
feat(404): update back home button to be compatible with custom theme

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,4 +1,4 @@
-import { Link } from '@mui/material';
+import { Link, Button } from '@mui/material';
 
 const pageNotfound = () => (
   <div className="not-found">
@@ -6,9 +6,9 @@ const pageNotfound = () => (
     <div className="not-found-background" />
     <h3>Looks like you&apos;re lost</h3>
     <p>Page you are looking for is missing.</p>
-    <Link href="/">
-      <a className="not-found-link">Go home</a>
-    </Link>
+    <Button component={Link} variant="contained" href="/" color="primary">
+      Go home
+    </Button>
   </div>
 );
 

--- a/src/style.css
+++ b/src/style.css
@@ -128,20 +128,6 @@ a {
   font-size: 4rem;
 }
 
-.not-found-link {
-  font-weight: bold;
-  color: #fff;
-  background-color: #86c232;
-  padding: 8px 7px;
-  border-radius: 5px;
-  border-top: 10px;
-}
-
-.not-found a:hover {
-  text-decoration: none;
-  color: #fff;
-}
-
 .not-found-background {
   background-image: url(./images/notfound.svg);
   width: auto;


### PR DESCRIPTION
# Description

- change styling to inherit from MUI button

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |
| :-----------------:|
![localhost_3000_trees_186735 (1)](https://user-images.githubusercontent.com/31519867/198898130-d30c76ef-4da4-4094-87a3-44a5c593c399.png)

|After|
|:-:|
![localhost_3000_trees_186735](https://user-images.githubusercontent.com/31519867/198898134-c3d04786-1691-43ec-b0bc-970425af2c6d.png)



# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
