### PR TITLE
1161 add reset typography input buttons

### DIFF
--- a/src/components/playground/ColorInput.js
+++ b/src/components/playground/ColorInput.js
@@ -87,7 +87,11 @@ function ColorInput(props) {
           >
             <span>{label}</span>
             <Tooltip title="Reset to Default">
-              <RestartAlt onClick={handleReset} color="error" />
+              <RestartAlt
+                sx={{ cursor: 'pointer' }}
+                onClick={handleReset}
+                color="error"
+              />
             </Tooltip>
           </Box>
         </InputLabel>

--- a/src/components/playground/ColorInput.js
+++ b/src/components/playground/ColorInput.js
@@ -2,14 +2,17 @@ import ColorizeIcon from '@mui/icons-material/Colorize';
 import RestartAlt from '@mui/icons-material/RestartAlt';
 import {
   Box,
-  TextField,
   IconButton,
   InputAdornment,
   Popover,
+  FormControl,
+  InputLabel,
+  Tooltip,
+  Input,
+  FormHelperText,
 } from '@mui/material';
 import { useState, useEffect, useRef } from 'react';
 import ColorPicker from 'react-best-gradient-color-picker';
-import SquareIconButton from './SquareIconButton';
 import { usePlaygroundUtils } from '../../hooks/contextHooks';
 import useDisclosure from '../../hooks/useDisclosure';
 import { propRules } from '../../models/themePlaygroundOptions';
@@ -34,6 +37,7 @@ function ColorInput(props) {
   const handleReset = () => {
     setValue(defaultColor);
     setPropByPath(path, defaultColor);
+    setValid(true);
   };
 
   const handleChange = (e) => {
@@ -61,34 +65,47 @@ function ColorInput(props) {
         flex: '1',
       }}
     >
-      <TextField
-        variant="standard"
+      <FormControl
         error={!isValid}
-        multiline={isGradient}
-        label={label}
-        value={value}
-        onChange={handleChange}
         sx={{
           textTransform: 'capitalize',
           width: 1,
         }}
-        helperText={!isValid && 'Invalid syntax'}
-        InputProps={{
-          endAdornment: (
+        variant="standard"
+      >
+        <InputLabel
+          sx={{
+            width: '130%',
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <span>{label}</span>
+            <Tooltip title="Reset to Default">
+              <RestartAlt onClick={handleReset} color="error" />
+            </Tooltip>
+          </Box>
+        </InputLabel>
+        <Input
+          multiline={isGradient}
+          value={value}
+          onChange={handleChange}
+          endAdornment={
             <InputAdornment position="end">
               <IconButton onClick={onOpen} ref={pickerRef}>
                 <ColorizeIcon />
               </IconButton>
-              <SquareIconButton
-                icon={<RestartAlt />}
-                color="error"
-                tooltip="Reset to default"
-                onClick={handleReset}
-              />
             </InputAdornment>
-          ),
-        }}
-      />
+          }
+        />
+        <FormHelperText>{!isValid && 'Invalid syntax'}</FormHelperText>
+      </FormControl>
+
       <Popover
         open={isOpen}
         onClose={onClose}

--- a/src/components/playground/TypographyInput.js
+++ b/src/components/playground/TypographyInput.js
@@ -1,3 +1,4 @@
+import { RestartAlt } from '@mui/icons-material';
 import {
   Box,
   TextField,
@@ -6,10 +7,17 @@ import {
   Select,
   MenuItem,
   InputLabel,
+  Tooltip,
+  Container,
+  FormControl,
+  Input,
+  FormHelperText,
+  FilledInput,
 } from '@mui/material';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, Fragment } from 'react';
 import { loadFonts } from 'models/utils';
 import FontSelector from './FontSelector';
+import SquareIconButton from './SquareIconButton';
 import {
   usePlaygroundUtils,
   usePlaygroundFonts,
@@ -34,6 +42,7 @@ function FontFamilyWeightElm(props) {
   const [fonts, setFonts] = usePlaygroundFonts();
   const initialValue = getPropByPath(path);
   const [value, setValue] = useState('');
+  const [defaultValue, setDefaultValue] = useState(initialValue.toString());
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -83,6 +92,11 @@ function FontFamilyWeightElm(props) {
     [fontValue, fonts, path, setFonts, setPropByPath],
   );
 
+  const resetTypography = () => {
+    setValue(defaultValue);
+    setPropByPath(path, defaultValue);
+  };
+
   const handleChange = (e) => {
     const userInput = e.target.value;
     setValue(userInput);
@@ -97,24 +111,32 @@ function FontFamilyWeightElm(props) {
   };
 
   return (
-    <TextField
-      variant="standard"
-      error={error.length > 0}
-      label="Font Weight"
-      value={value}
-      onChange={handleChange}
-      sx={{
-        width: 1,
-      }}
-      helperText={error || 'Load Font weight.'}
-      InputProps={{
-        endAdornment: (
+    <FormControl error={error.length > 0} sx={{ width: 1 }} variant="standard">
+      <InputLabel sx={{ width: '133%' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+          }}
+        >
+          <span>Font Weight</span>
+          <Tooltip title="Reset to Default">
+            <RestartAlt onClick={resetTypography} color="error" />
+          </Tooltip>
+        </Box>
+      </InputLabel>
+      <Input
+        value={value}
+        onChange={handleChange}
+        endAdornment={
           <InputAdornment position="end">
             {loading ? <CircularProgress size="1.5rem" /> : null}
           </InputAdornment>
-        ),
-      }}
-    />
+        }
+      />
+      <FormHelperText>{error || 'Load Font weight.'}</FormHelperText>
+    </FormControl>
   );
 }
 
@@ -123,12 +145,18 @@ function FontFamily(props) {
   const { getPropByPath, setPropByPath } = usePlaygroundUtils();
   const initialValue = getPropByPath(path);
   const [value, setValue] = useState(initialValue);
+  const [defaultValue, setDefaultValue] = useState(initialValue);
   const [fonts] = usePlaygroundFonts();
   const [error, setError] = useState('');
   const fontWeightPath = `${path
     .split('.')
     .splice(0, path.split('.').length - 1)
     .join('.')}.fontWeight`;
+
+  const resetTypography = () => {
+    setValue(defaultValue);
+    setPropByPath(path, defaultValue);
+  };
 
   const handleChange = (e) => {
     const userInput =
@@ -148,27 +176,43 @@ function FontFamily(props) {
 
   return (
     <>
-      <TextField
-        select
-        id="fontFamily"
-        variant="standard"
-        label={label}
-        value={value}
+      <FormControl
+        id="font-family"
         error={error.length > 0}
-        onChange={handleChange}
-        helperText={error || 'Add Fontfamily from loaded families.'}
         sx={{
           textTransform: 'capitalize',
           width: 1,
           marginBottom: '5px',
+          pt: 1,
         }}
+        variant="standard"
       >
-        {Object.keys(fonts).map((font) => (
-          <MenuItem value={font} key={`font-selector-menuitem-${font}`}>
-            {font}
-          </MenuItem>
-        ))}
-      </TextField>
+        <InputLabel sx={{ width: '133%' }}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            {label}
+            <Tooltip title="Reset to Default">
+              <RestartAlt onClick={resetTypography} color="error" />
+            </Tooltip>
+          </Box>
+        </InputLabel>
+        <Select value={value} onChange={handleChange}>
+          {Object.keys(fonts).map((font) => (
+            <MenuItem value={font} key={`font-selector-menuitem-${font}`}>
+              {font}
+            </MenuItem>
+          ))}
+        </Select>
+        <FormHelperText>
+          {error || 'Add Fontfamily from loaded families.'}
+        </FormHelperText>
+      </FormControl>
+
       <FontFamilyWeightElm
         label="fontWeight"
         path={fontWeightPath}
@@ -184,10 +228,17 @@ function TypographyInput(props) {
   const initialValue = getPropByPath(path);
   const [value, setValue] = useState(initialValue);
   const [isValid, setValid] = useState(true);
+  const [defaultValue, setDefaultValue] = useState(initialValue);
 
   useEffect(() => {
     setValue(initialValue);
   }, [initialValue]);
+
+  const resetTypography = () => {
+    setPropByPath(path, defaultValue);
+    setValue(defaultValue);
+    setValid(true);
+  };
 
   const handleChange = (e) => {
     const userValue = e.target.value;
@@ -208,18 +259,56 @@ function TypographyInput(props) {
       {label === 'fontFamily' ? (
         <FontFamily label={label} path={path} />
       ) : (
-        <TextField
-          variant="standard"
+        <FormControl
           error={!isValid}
-          label={label}
-          value={value}
-          onChange={handleChange}
           sx={{
             textTransform: 'capitalize',
             width: 1,
+            pt: 1,
           }}
-          helperText={!isValid && 'Invalid syntax'}
-        />
+          variant="standard"
+        >
+          <InputLabel sx={{ width: '133%' }}>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+              }}
+            >
+              {label}
+              <Tooltip title="Reset to Default">
+                <RestartAlt onClick={resetTypography} color="error" />
+              </Tooltip>
+            </Box>
+          </InputLabel>
+          <Input value={value} onChange={handleChange} />
+          <FormHelperText>{!isValid && 'Invalid syntax'}</FormHelperText>
+        </FormControl>
+        // <TextField
+        //   variant="standard"
+        //   error={!isValid}
+        //   label={
+        //     <>
+        //       {label}
+        //       <SquareIconButton
+        //         icon={<RestartAlt />}
+        //         color="error"
+        //         tooltip="Reset to default"
+        //         onClick={resetTypography}
+        //         sx={{ ml: 43.8, mb: 0.5 }}
+        //       />
+        //     </>
+        //   }
+        //   value={value}
+        //   onChange={handleChange}
+        //   sx={{
+        //     textTransform: 'capitalize',
+        //     width: 1,
+        //     pt: 1,
+        //   }}
+        //   helperText={!isValid && 'Invalid syntax'}
+        // />
       )}
     </Box>
   );

--- a/src/components/playground/TypographyInput.js
+++ b/src/components/playground/TypographyInput.js
@@ -117,7 +117,7 @@ function FontFamilyWeightElm(props) {
           }}
         >
           <span>Font Weight</span>
-          <Tooltip title="Reset to Default">
+          <Tooltip sx={{ cursor: 'pointer' }} title="Reset to Default">
             <RestartAlt onClick={resetTypography} color="error" />
           </Tooltip>
         </Box>
@@ -192,7 +192,7 @@ function FontFamily(props) {
             }}
           >
             {label}
-            <Tooltip title="Reset to Default">
+            <Tooltip sx={{ cursor: 'pointer' }} title="Reset to Default">
               <RestartAlt onClick={resetTypography} color="error" />
             </Tooltip>
           </Box>
@@ -273,7 +273,7 @@ function TypographyInput(props) {
               }}
             >
               {label}
-              <Tooltip title="Reset to Default">
+              <Tooltip sx={{ cursor: 'pointer' }} title="Reset to Default">
                 <RestartAlt onClick={resetTypography} color="error" />
               </Tooltip>
             </Box>

--- a/src/components/playground/TypographyInput.js
+++ b/src/components/playground/TypographyInput.js
@@ -1,23 +1,19 @@
 import { RestartAlt } from '@mui/icons-material';
 import {
   Box,
-  TextField,
   InputAdornment,
   CircularProgress,
   Select,
   MenuItem,
   InputLabel,
   Tooltip,
-  Container,
   FormControl,
   Input,
   FormHelperText,
-  FilledInput,
 } from '@mui/material';
-import { useState, useEffect, useCallback, Fragment } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { loadFonts } from 'models/utils';
 import FontSelector from './FontSelector';
-import SquareIconButton from './SquareIconButton';
 import {
   usePlaygroundUtils,
   usePlaygroundFonts,
@@ -285,30 +281,6 @@ function TypographyInput(props) {
           <Input value={value} onChange={handleChange} />
           <FormHelperText>{!isValid && 'Invalid syntax'}</FormHelperText>
         </FormControl>
-        // <TextField
-        //   variant="standard"
-        //   error={!isValid}
-        //   label={
-        //     <>
-        //       {label}
-        //       <SquareIconButton
-        //         icon={<RestartAlt />}
-        //         color="error"
-        //         tooltip="Reset to default"
-        //         onClick={resetTypography}
-        //         sx={{ ml: 43.8, mb: 0.5 }}
-        //       />
-        //     </>
-        //   }
-        //   value={value}
-        //   onChange={handleChange}
-        //   sx={{
-        //     textTransform: 'capitalize',
-        //     width: 1,
-        //     pt: 1,
-        //   }}
-        //   helperText={!isValid && 'Invalid syntax'}
-        // />
       )}
     </Box>
   );


### PR DESCRIPTION
# Description

[comment]: #
added reset button to the typography section in admin/theme also made the css changes to the color selection area
Fixes #1161 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x ] New feature (non-breaking change which adds functionality)


## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

before, no button 
![image](https://user-images.githubusercontent.com/63400531/201468768-1a05eb05-a74e-42df-9b19-e6827f1a0447.png)
![image](https://user-images.githubusercontent.com/63400531/201468785-d0af8e0b-9469-4bad-a40a-d9cf271bfefc.png)



# How Has This Been Tested?


- [x ] Cypress component tests


# Checklist:

- [x ] I have performed a self-review of my own code

- [x ] My changes generate no new warnings

- [x ] New and existing unit tests pass locally with my changes

