### PR TITLE
feat(theme): add icon alongside custom font

### DIFF
--- a/src/components/playground/FontSelector.js
+++ b/src/components/playground/FontSelector.js
@@ -1,11 +1,14 @@
 import AddIcon from '@mui/icons-material/Add';
+import FontDownloadIcon from '@mui/icons-material/FontDownload';
 import { Menu, MenuItem } from '@mui/material';
 import { useState } from 'react';
+import { predefinedFonts } from 'models/themePlaygroundOptions';
 import { usePlaygroundFonts } from '../../hooks/contextHooks';
 
 function FontSelector(props) {
   const { handleChange } = props;
   const [fonts, setFonts] = usePlaygroundFonts();
+  const defaultFonts = predefinedFonts;
 
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
@@ -46,7 +49,7 @@ function FontSelector(props) {
             key={`font-selector-menutitem-${font}`}
             onClick={() => handleClose(font)}
           >
-            {font}
+            {font} {!(font in defaultFonts) && <FontDownloadIcon />}
           </MenuItem>
         ))}
       </Menu>

--- a/src/components/playground/FontSelector.js
+++ b/src/components/playground/FontSelector.js
@@ -1,14 +1,11 @@
 import AddIcon from '@mui/icons-material/Add';
-import FontDownloadIcon from '@mui/icons-material/FontDownload';
 import { Menu, MenuItem } from '@mui/material';
 import { useState } from 'react';
-import { predefinedFonts } from 'models/themePlaygroundOptions';
 import { usePlaygroundFonts } from '../../hooks/contextHooks';
 
 function FontSelector(props) {
   const { handleChange } = props;
   const [fonts, setFonts] = usePlaygroundFonts();
-  const defaultFonts = predefinedFonts;
 
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
@@ -49,7 +46,7 @@ function FontSelector(props) {
             key={`font-selector-menutitem-${font}`}
             onClick={() => handleClose(font)}
           >
-            {font} {!(font in defaultFonts) && <FontDownloadIcon />}
+            {font}
           </MenuItem>
         ))}
       </Menu>

--- a/src/components/playground/TypographyInput.js
+++ b/src/components/playground/TypographyInput.js
@@ -20,7 +20,7 @@ import {
   usePlaygroundFonts,
 } from '../../hooks/contextHooks';
 import {
-  predefinedFonts,
+  predefinedFonts as defaultFonts,
   propRules,
 } from '../../models/themePlaygroundOptions';
 
@@ -152,7 +152,6 @@ function FontFamily(props) {
     .split('.')
     .splice(0, path.split('.').length - 1)
     .join('.')}.fontWeight`;
-  const defaultFonts = predefinedFonts;
 
   const resetTypography = () => {
     setValue(defaultValue);

--- a/src/components/playground/TypographyInput.js
+++ b/src/components/playground/TypographyInput.js
@@ -1,4 +1,5 @@
 import { RestartAlt } from '@mui/icons-material';
+import FontDownloadIcon from '@mui/icons-material/FontDownload';
 import {
   Box,
   InputAdornment,
@@ -18,7 +19,10 @@ import {
   usePlaygroundUtils,
   usePlaygroundFonts,
 } from '../../hooks/contextHooks';
-import { propRules } from '../../models/themePlaygroundOptions';
+import {
+  predefinedFonts,
+  propRules,
+} from '../../models/themePlaygroundOptions';
 
 const allowedFontWeights = new Set([
   'normal',
@@ -148,6 +152,7 @@ function FontFamily(props) {
     .split('.')
     .splice(0, path.split('.').length - 1)
     .join('.')}.fontWeight`;
+  const defaultFonts = predefinedFonts;
 
   const resetTypography = () => {
     setValue(defaultValue);
@@ -200,7 +205,10 @@ function FontFamily(props) {
         <Select value={value} onChange={handleChange}>
           {Object.keys(fonts).map((font) => (
             <MenuItem value={font} key={`font-selector-menuitem-${font}`}>
-              {font}
+              {font}{' '}
+              <span style={{ marginLeft: 'auto' }}>
+                {!(font in defaultFonts) && <FontDownloadIcon />}
+              </span>
             </MenuItem>
           ))}
         </Select>


### PR DESCRIPTION
# Description


Fixes #1174

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] New feature (non-breaking change which adds functionality)


## Screenshots

<img width="367" alt="icon-custom-font" src="https://user-images.githubusercontent.com/53157755/201781690-73ed550b-dfad-47fd-bd5a-75f3d8a3a655.png">


# Checklist:

- [x] I have performed a self-review of my own code

