### PR TITLE
fix: Change text color on hover

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -133,6 +133,9 @@ export default function Home(props) {
               <Box
                 sx={{
                   color: 'white',
+                  '.MuiBox-root&:hover': {
+                    color: '#adadad',
+                  },
                 }}
               >
                 Learn more


### PR DESCRIPTION
# Description

Make text readable on hover.

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="200" alt="button_before" src="https://user-images.githubusercontent.com/53157755/202338233-2f19de16-fc06-43aa-b795-036348a69f8e.png"> | <img width="194" alt="button_after" src="https://user-images.githubusercontent.com/53157755/202338225-9a041674-0941-4b13-8f10-7a9403336878.png">|

# Checklist:

- [x] I have performed a self-review of my own code
