### PR TITLE
Revert "fix: added a simple mount test for theme in cypress"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "2.0.0-beta.170",
+  "version": "2.0.0-beta.136",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "2.0.0-beta.170",
+      "version": "2.0.0-beta.136",
       "dependencies": {
         "@emotion/cache": "^11.5.0",
         "@emotion/react": "^11.5.0",

--- a/src/pages/admin/theme.cy.js
+++ b/src/pages/admin/theme.cy.js
@@ -1,8 +1,0 @@
-import ThemePlayground from './theme';
-import { mountWithTheme as mount } from '../../models/test-utils';
-
-describe('Theme', () => {
-  it('renders', () => {
-    mount(<ThemePlayground />);
-  });
-});


### PR DESCRIPTION
Reverts Greenstand/treetracker-web-map-client#1198

I temporarily withdraw this, please raise PR again when we solved:

fix #1225 

https://github.com/Greenstand/treetracker-web-map-client/pull/1222#issuecomment-1334737920