### PR TITLE
fix: update search icon color to match figma

### DIFF
--- a/src/pages/top.js
+++ b/src/pages/top.js
@@ -125,11 +125,11 @@ function Top(props) {
             icon={Search}
             width={48}
             height={48}
-            color="grey"
+            color="primaryLight"
             sx={{
               fill: 'transparent',
               '& path': {
-                fill: 'grey',
+                fill: 'primary',
               },
             }}
           />


### PR DESCRIPTION
## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="86" alt="before search" src="https://user-images.githubusercontent.com/53157755/205220676-e808d01a-0884-4c24-bc3d-5fc86eaad969.png"> | <img width="86" alt="after-search" src="https://user-images.githubusercontent.com/53157755/205220691-7d2e6042-5507-4d86-86c1-3e86bde45792.png"> |


# Checklist:

- [x] I have performed a self-review of my own code

