### PR TITLE
fix: timeline appears on when expand button is clicked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "2.0.0-beta.136",
+  "version": "2.0.0-beta.185",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "2.0.0-beta.136",
+      "version": "2.0.0-beta.185",
       "dependencies": {
         "@emotion/cache": "^11.5.0",
         "@emotion/react": "^11.5.0",

--- a/src/components/LayoutEmbed.js
+++ b/src/components/LayoutEmbed.js
@@ -6,6 +6,7 @@ import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import React from 'react';
 import SearchFilter from './SearchFilter';
+import Timeline from './Timeline';
 import { useEmbed } from '../hooks/globalHooks';
 import LogoIcon from '../images/greenstand_logo_full.png';
 import MinIcon from '../images/min.svg';
@@ -207,6 +208,7 @@ export default function Layout({
           />
         </Box>
       )}
+      <Timeline />
       <Box
         sx={{
           position: 'absolute',


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

When the expand button is clicked, The timeline filter would disappear. This PR corrects this issue. 

Fixes # 1193

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| "screenshot before" | "screenshot after" |
| ![image](https://user-images.githubusercontent.com/5744708/202387842-31707db3-c5d7-4f61-921a-9cc8688c9d8f.png) | ![image](https://user-images.githubusercontent.com/30008919/205402928-a9fa8ace-9000-4ef5-845b-84bf60ffd3d9.png)|

PR Demo (Optional):
[video](https://www.loom.com/share/f1d1b3e5f563423f93b94d2b9fd673aa)


# How Has This Been Tested?

- [X] Cypress integration
- [X] Cypress component tests
- [X] Jest unit tests

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
