### PR TITLE
fix: alignment issue

### DIFF
--- a/src/components/common/TreeTag.js
+++ b/src/components/common/TreeTag.js
@@ -11,6 +11,7 @@ function TreeTagComponent({
   icon,
   disabled = false,
   link,
+  fullWidth = false,
 }) {
   const chip = (
     <Chip
@@ -54,6 +55,11 @@ function TreeTagComponent({
         p: (t) => [t.spacing(2, 2), t.spacing(4.75, 6)],
         height: 'auto',
         maxHeight: [58.6, 87.2],
+        ...(fullWidth && {
+          justifyContent: 'flex-start',
+          width: '100%',
+          maxWidth: '540px',
+        }),
       }}
       color="secondary"
       icon={

--- a/src/pages/wallets/[walletid].js
+++ b/src/pages/wallets/[walletid].js
@@ -305,6 +305,7 @@ export default function Wallet(props) {
                 title="Token ID"
                 icon={<Icon icon={TokenIcon} />}
                 link={`/wallets/${wallet.id}/tokens/${token.id}`}
+                fullWidth
               />
             </Box>
           ))}


### PR DESCRIPTION
# Description

Align TreeTags on the wallet page.

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="658" alt="not aligned" src="https://user-images.githubusercontent.com/53157755/205770368-df6ee916-0d27-4738-bfe2-0bbbc52edf41.png"> | <img width="652" alt="aligned" src="https://user-images.githubusercontent.com/53157755/205769442-892029ab-f7f3-4904-89e1-607d00bdc5b3.png"> |




# Checklist:

- [x] I have performed a self-review of my own code

