### PR TITLE
fix: CustomWorldMap on organization page

### DIFF
--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -368,7 +368,7 @@ export default function Organization(props) {
                     )) ||
                   undefined
                 }
-                con="af"
+                con={organization?.continent_name || 'af'}
               />
             </Box>
             <Typography


### PR DESCRIPTION
# Description

Replace hardcoded continent value for CustomWorldMap with prop.

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
