### PR TITLE
fix: embeded background was white in dark mode

### DIFF
--- a/src/components/LayoutEmbed.js
+++ b/src/components/LayoutEmbed.js
@@ -110,7 +110,7 @@ export default function Layout({
                   position: 'absolute',
                   zIndex: '99999',
                   top: '0px',
-                  background: 'white',
+                  // background: 'white',
                   width: 568,
                   overflowY: 'scroll',
                   height: '100vh',


### PR DESCRIPTION
# Description

[comment]: # 
background color in the layoutembed.js file was hardcoded a background color of white, this is why it never changed when you changed the theme to dark mode.

Fixes #1236 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x ] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

before: [loomBefore](https://www.loom.com/share/90e72788afec4547b0ebd4e60744a194)
after: [loomAfter](https://www.loom.com/share/eaae4870b05d47fa8c2467dea38e31c0)

# How Has This Been Tested?

myself by looking at the colors 😆 

# Checklist:

- [x ] I have performed a self-review of my own code

- [ x] My changes generate no new warnings

