### PR TITLE
fix: transaction history on token page

### DIFF
--- a/src/pages/tokens/[tokenid].js
+++ b/src/pages/tokens/[tokenid].js
@@ -502,7 +502,7 @@ export default function Token(props) {
               <TimelineOppositeContent
                 color="text.secondary"
                 sx={{
-                  flex: [0.4, 0.2],
+                  flex: '0 0 100px',
                 }}
               >
                 {new Date(token.created_at).toLocaleDateString()}
@@ -531,7 +531,7 @@ export default function Token(props) {
               <TimelineItem key={transaction.id}>
                 <TimelineOppositeContent
                   sx={{
-                    flex: [0.4, 0.2],
+                    flex: '0 0 100px',
                   }}
                   color="text.secondary"
                 >
@@ -619,7 +619,7 @@ export default function Token(props) {
             <TimelineItem>
               <TimelineOppositeContent
                 sx={{
-                  flex: [0.4, 0.2],
+                  flex: '0 0 100px',
                 }}
                 color="text.secondary"
               >


### PR DESCRIPTION
# Description

Transaction history breaks on smaller screen size. This fix aligns the timeline.

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="516" alt="before" src="https://user-images.githubusercontent.com/53157755/207737693-6e7bf590-e731-442a-b33d-ef1dadee7fc5.png"> |<img width="527" alt="after" src="https://user-images.githubusercontent.com/53157755/207737703-ac1e13d6-4a4b-4202-8f87-0d7b779bb854.png"> |


# How Has This Been Tested?

- [x] Checked on desktop and mobile

# Checklist:

- [x] I have performed a self-review of my own code

