### PR TITLE
fix: alignment issue with textfield

### DIFF
--- a/src/components/GlobalMapLayout.js
+++ b/src/components/GlobalMapLayout.js
@@ -176,7 +176,6 @@ export default function MapLayout() {
           sx={{
             margin: '20px',
             display: 'flex',
-            alignItems: 'center',
             justifyContent: 'space-around',
           }}
         >
@@ -203,6 +202,11 @@ export default function MapLayout() {
             value={zoom}
             error={zoomError.length > 0}
             helperText={zoomError && zoomError}
+            sx={{
+              '& .MuiFormHelperText-root': {
+                maxWidth: '167px',
+              },
+            }}
           />
         </Box>
         <Box


### PR DESCRIPTION
# Description

Textfield alignment breaks when invalid value is entered in the zoom field. Fixed it.


## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="996" alt="not-a" src="https://user-images.githubusercontent.com/53157755/208324976-c177e1e2-e4a1-4f2f-b250-153058ce974b.png"> | <img width="1065" alt="a" src="https://user-images.githubusercontent.com/53157755/208324978-0f207a3e-c07e-4434-a625-fa7e2bbfc13c.png"> |


# Checklist:

- [x] I have performed a self-review of my own code
