### PR TITLE
fix(home): replace hard-coded vals with palette vals

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -134,7 +134,7 @@ export default function Home(props) {
                 sx={{
                   color: 'white',
                   '.MuiBox-root&:hover': {
-                    color: '#adadad',
+                    color: 'brightGrey.main',
                   },
                 }}
               >
@@ -142,13 +142,14 @@ export default function Home(props) {
               </Box>
             </Link>
           </Button>
+
           <Link href="/top">
             <Button
               variant="contained"
               color="primaryLight"
               className={classes.button}
               sx={{
-                color: '#474B4F',
+                color: 'darkGrey.main',
                 ml: [4, 6],
                 '.MuiButton-root&:hover': {
                   color: 'white',

--- a/src/context/themeContext.js
+++ b/src/context/themeContext.js
@@ -168,6 +168,18 @@ export function buildTheme(theMode) {
             }),
       },
       // a light orange color, used in some components as background color
+      brightGrey: {
+        ...(themeMode === 'light'
+          ? {
+              main: '#adadad',
+              contrastText: '#fff',
+            }
+          : {
+              main: '#adadad',
+              contrastText: '#fff',
+            }),
+      },
+
       greyLight: {
         ...(themeMode === 'light'
           ? {


### PR DESCRIPTION
Added in new palette value "#adadad".

# Description

[comment]: # 'Updated hard-coded color values in "Let's Find a Tree" and "Learn More" buttons with values found in the Theme Palette. Added a theme palette value named "brightGrey" to have the #adadad value available. resolves #1257'


Fixes #1257


## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'



| [before](https://user-images.githubusercontent.com/48111116/208551786-f9eab2c2-79f5-450d-9ae8-2730ed44d373.PNG)
 |  [after](https://user-images.githubusercontent.com/48111116/208551846-2d8b3236-d336-4eb6-93a7-b276b661a237.PNG)


# How Has This Been Tested?

Visually looks the same.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
