### PR TITLE
perf: add dimension to tree image

### DIFF
--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -368,7 +368,11 @@ export default function Tree({
               position: 'relative',
               overflow: 'hidden',
               '& img': {
+                objectFit: 'cover',
                 width: '100%',
+                [theme.breakpoints.down('sm')]: {
+                  maxHeight: '450px',
+                },
               },
             },
             nextExtraIsEmbed && {
@@ -424,7 +428,7 @@ export default function Tree({
               />
             </Box>
           </Box>
-          <img src={tree.image_url} alt="tree" />
+          <img src={tree.image_url} alt="tree" height="764" />
           {!isMobile && (
             <Box
               sx={{


### PR DESCRIPTION


## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Desktop       |       Mobile        |
| :-----------------: | :----------------: |
| <img width="1434" alt="tree_desktop" src="https://user-images.githubusercontent.com/53157755/208785197-37f8fa53-059a-46d0-912a-f1fad0e6eb3c.png"> | <img width="251" alt="tree_mobile" src="https://user-images.githubusercontent.com/53157755/208785207-acaf8170-8172-4490-bdb4-86d58778e0a3.png"> |

# Checklist:

- [x] I have performed a self-review of my own code

