### PR TITLE
perf: add dimension to cover photo

### DIFF
--- a/src/components/ProfileCover.js
+++ b/src/components/ProfileCover.js
@@ -16,7 +16,7 @@ function ProfileCover({ src }) {
           },
         }}
       >
-        <img src={src} alt="profile" />
+        <img src={src} alt="profile" height="328" />
       </Box>
     );
   }


### PR DESCRIPTION
## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Desktop        |       Mobile        |
| :-----------------: | :----------------: |
| <img width="1440" alt="cover_desktop" src="https://user-images.githubusercontent.com/53157755/208791528-921ca1d9-fd7f-4186-b350-9186ad4d0b08.png"> | <img width="244" alt="cover_mobile" src="https://user-images.githubusercontent.com/53157755/208791522-58302691-af0e-4e5a-a742-e09d11b904cd.png"> |


# Checklist:

- [x] I have performed a self-review of my own code

