### PR TITLE
fix: icon color 

### DIFF
--- a/src/components/common/Info.js
+++ b/src/components/common/Info.js
@@ -10,13 +10,19 @@ export default function Info({ info, iconURI }) {
         alignItems: 'center',
         gap: 3,
         '& svg': {
-          filter: 'opacity(0.5)',
           maxWidth: 16,
           maxHeight: 16,
         },
       }}
     >
-      <Icon icon={iconURI} />
+      <Icon
+        icon={iconURI}
+        sx={{
+          '& path': {
+            fill: ({ palette }) => palette.text.text2,
+          },
+        }}
+      />
       <Typography variant="h6">{info}</Typography>
     </Box>
   );


### PR DESCRIPTION
# Description

Hard to see icons on dark mode. This fix updates the Icon color for better contrast.


## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
|<img width="490" alt="Organization since July 23, 2020" src="https://user-images.githubusercontent.com/53157755/209021955-b0692b06-8d74-4418-8264-75d208d2d19d.png"> | <img width="372" alt="light-a" src="https://user-images.githubusercontent.com/53157755/209021936-6b50d53d-e66e-4de9-9307-f34102c9e79c.png"> <img width="343" alt="dark-a" src="https://user-images.githubusercontent.com/53157755/209021949-d536e77b-ea8e-45d9-9fda-b10673b4e8ad.png"> |



# Checklist:

- [x] I have performed a self-review of my own code
