### PR TITLE
fix: planter incorrect image rotation on organization page

### DIFF
--- a/src/components/PlanterQuote.js
+++ b/src/components/PlanterQuote.js
@@ -1,25 +1,15 @@
-import {
-  Avatar,
-  Button,
-  Box,
-  Grid,
-  Typography,
-  useTheme,
-  SvgIcon,
-} from '@mui/material';
+import { Box, Typography, useTheme, SvgIcon } from '@mui/material';
 import * as d3 from 'd3';
 import log from 'loglevel';
 import moment from 'moment';
-import Image from 'next/image';
 import { getLocationString } from 'models/utils';
 import Link from './Link';
+import ProfileAvatar from './ProfileAvatar';
 import ColorButton from './common/ColorButton';
-import DataTag from './common/DataTag';
 import Info from './common/Info';
 import { useMobile } from '../hooks/globalHooks';
 import CalendarIcon from '../images/icons/calendar.svg';
 import LocationIcon from '../images/icons/location.svg';
-import PeopleIcon from '../images/icons/people.svg';
 import imagePlaceholder from '../images/image-placeholder.png';
 import QuoteImgReverse from '../images/quote-reverse.svg';
 import QuoteImg from '../images/quote-symbol.svg';
@@ -75,8 +65,9 @@ function PlanterQuote(props) {
           alignItems: 'center',
         }}
       >
-        <Avatar
+        <ProfileAvatar
           src={photo}
+          rotation={planter.image_rotation}
           sx={{
             zIndex: '1',
             width: [90, 180],
@@ -84,6 +75,7 @@ function PlanterQuote(props) {
             filter: 'drop-shadow(0px 10px 20px rgba(0, 0, 0, 0.25))',
             order: reverse ? 1 : 0,
             ml: reverse ? [26 / 8, 26 / 4] : 0,
+            mt: 'none',
           }}
         />
         <Box

--- a/src/components/PlanterQuote.js
+++ b/src/components/PlanterQuote.js
@@ -58,6 +58,7 @@ function PlanterQuote(props) {
         <ProfileAvatar
           src={photo}
           rotation={planter.image_rotation}
+          noBackground
           sx={{
             zIndex: '1',
             width: [90, 180],

--- a/src/components/PlanterQuote.js
+++ b/src/components/PlanterQuote.js
@@ -1,4 +1,4 @@
-import { Box, Typography, useTheme, SvgIcon } from '@mui/material';
+import { Box, Typography, SvgIcon } from '@mui/material';
 import * as d3 from 'd3';
 import log from 'loglevel';
 import moment from 'moment';
@@ -7,7 +7,6 @@ import Link from './Link';
 import ProfileAvatar from './ProfileAvatar';
 import ColorButton from './common/ColorButton';
 import Info from './common/Info';
-import { useMobile } from '../hooks/globalHooks';
 import CalendarIcon from '../images/icons/calendar.svg';
 import LocationIcon from '../images/icons/location.svg';
 import imagePlaceholder from '../images/image-placeholder.png';
@@ -18,14 +17,7 @@ import QuoteImg from '../images/quote-symbol.svg';
 function PlanterQuote(props) {
   log.warn('props:', props);
   const { planter, reverse = false } = props;
-  const {
-    id,
-    about: quote2,
-    name,
-    image_url: photo2,
-    created_at,
-    location,
-  } = planter;
+  const { id, about: quote2, name, image_url: photo2 } = planter;
 
   let quote = quote2 || "the planter hasn't left any quote yet";
   if (quote.length > 500) {
@@ -33,8 +25,6 @@ function PlanterQuote(props) {
   }
   const photo = photo2 || imagePlaceholder;
 
-  const theme = useTheme();
-  const isMobile = useMobile();
   return (
     <Box
       sx={{
@@ -75,7 +65,7 @@ function PlanterQuote(props) {
             filter: 'drop-shadow(0px 10px 20px rgba(0, 0, 0, 0.25))',
             order: reverse ? 1 : 0,
             ml: reverse ? [26 / 8, 26 / 4] : 0,
-            mt: 'none',
+            mt: 0,
           }}
         />
         <Box

--- a/src/components/ProfileAvatar.js
+++ b/src/components/ProfileAvatar.js
@@ -1,6 +1,6 @@
 import { Avatar } from '@mui/material';
 
-function ProfileAvatar({ src, rotation }) {
+function ProfileAvatar({ src, rotation, sx }) {
   return (
     <Avatar
       src={src}
@@ -15,6 +15,7 @@ function ProfileAvatar({ src, rotation }) {
         boxSizing: 'border-box',
         ml: [4, 8],
         mt: [-98 / 4, -146 / 4],
+        ...sx,
       }}
     />
   );

--- a/src/components/ProfileAvatar.js
+++ b/src/components/ProfileAvatar.js
@@ -8,6 +8,7 @@ function ProfileAvatar({ src, rotation, sx = {}, noBackground = false }) {
         width: [120, 189],
         height: [120, 189],
         transform: rotation && `rotate(${rotation}deg)`,
+        boxSizing: 'border-box',
         ml: [4, 8],
         mt: [-98 / 4, -146 / 4],
         ...(noBackground
@@ -17,7 +18,6 @@ function ProfileAvatar({ src, rotation, sx = {}, noBackground = false }) {
               borderStyle: 'solid',
               borderColor: (t) => t.palette.background.paper,
               backgroundColor: (t) => t.palette.background.avatar,
-              boxSizing: 'border-box',
             }),
         ...sx,
       }}

--- a/src/components/ProfileAvatar.js
+++ b/src/components/ProfileAvatar.js
@@ -1,6 +1,6 @@
 import { Avatar } from '@mui/material';
 
-function ProfileAvatar({ src, rotation, sx }) {
+function ProfileAvatar({ src, rotation, sx = {}, noBackground = false }) {
   return (
     <Avatar
       src={src}
@@ -8,13 +8,17 @@ function ProfileAvatar({ src, rotation, sx }) {
         width: [120, 189],
         height: [120, 189],
         transform: rotation && `rotate(${rotation}deg)`,
-        borderWidth: [4, 9],
-        borderStyle: 'solid',
-        borderColor: (t) => t.palette.background.paper,
-        backgroundColor: (t) => t.palette.background.avatar,
-        boxSizing: 'border-box',
         ml: [4, 8],
         mt: [-98 / 4, -146 / 4],
+        ...(noBackground
+          ? {}
+          : {
+              borderWidth: [4, 9],
+              borderStyle: 'solid',
+              borderColor: (t) => t.palette.background.paper,
+              backgroundColor: (t) => t.palette.background.avatar,
+              boxSizing: 'border-box',
+            }),
         ...sx,
       }}
     />


### PR DESCRIPTION
# Description

 Planters' images are shown in the proper orientation on the Organization page.
 - Modified the `ProfileAvatar` Component; introduced `sx` props.
 - Change the `Avatar` component to the `ProfileAvatar` component and use the `image_rotation` property from the `planter` object.
 - Removed unused imports.

Fixes #1306

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
|:-----------------: | :----------------: |
|![208920633-8c7dd065-5e80-494c-9cbf-21a0c6ccd953](https://user-images.githubusercontent.com/8200073/209155871-dd37fd99-d6d8-48b4-a12e-1b1327081bb0.png) | ![image](https://user-images.githubusercontent.com/8200073/209156843-fd2df136-6b64-4425-891f-73b581fa04ac.png)|


# Checklist:

- [x] I have performed a self-review of my own code
