### PR TITLE
fix: show date error on expand screen

### DIFF
--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -120,7 +120,17 @@ function Timeline() {
     isGlobalPage && (
       <>
         {isError && (
-          <Alert severity="error">Start date must be before end date</Alert>
+          <Alert
+            severity="error"
+            sx={{
+              position: 'absolute',
+              zIndex: '9999',
+              top: '10px',
+              left: '10px',
+            }}
+          >
+            Start date must be before end date
+          </Alert>
         )}
         <Paper
           elevation={7}

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -125,8 +125,8 @@ function Timeline() {
             sx={{
               position: 'absolute',
               zIndex: '9999',
-              top: '10px',
-              left: '10px',
+              top: '20px',
+              left: '20px',
             }}
           >
             Start date must be before end date

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -127,6 +127,7 @@ function Timeline() {
               zIndex: '9999',
               top: '20px',
               left: '20px',
+              alignItems: 'center',
             }}
           >
             Start date must be before end date


### PR DESCRIPTION
# Description

No error is shown when the expand button is clicked and an invalid date range is selected on the timeline. This change fixes it.


## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have performed a self-review of my own code
