### PR TITLE
On-demand Manual Cache Refresh

### DIFF
--- a/src/models/api.js
+++ b/src/models/api.js
@@ -137,3 +137,19 @@ export async function getTokenById(id) {
     throw err;
   }
 }
+
+// establishing an ondemand revalidation route 
+export default async function handler(req, res){
+  const {params, secret} = {params: req.params, secret: req.query.secret}
+  console.log(secret);
+  if(secret !== process.env.ondemand_token) {
+    return res.status(401).json({message: 'Invalid Token'});
+  }
+  try {
+    await res.revalidate(`/organizations/${params}`);
+    return res.json({revalidated: true});
+  } catch (e) {
+    //log the error to a service via log.error
+    return res.status(500).send('Error revalidating')
+  }
+}

--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -31,6 +31,7 @@ import { useMapContext } from '../../mapContext';
 import * as pathResolver from '../../models/pathResolver';
 import { getLocationString, getContinent, wrapper } from '../../models/utils';
 
+
 export default function Organization(props) {
   log.warn('props for org page:', props);
   const { organization, nextExtraIsEmbed } = props;


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

The change involves adding a route handler that refreshes the cache on-demand, so planters and organization, especially ones that recently joined the tree tracker app, can view their information immediately within the application.  

Fixes # 1277

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| "screenshot before" | "screenshot after" |

# How Has This Been Tested?

- [X] Cypress integration
- [X] Cypress component tests
- [X] Jest unit tests

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
