### PR TITLE
chore: cypress command run nock by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,16 +195,16 @@ Open cypress test viewer
 npm run cypress:open
 ```
 
-Nextjs dev server + Cypress test viewer
+Nextjs dev server + Cypress test viewer + nock
 
 ```
 npm run cy
 ```
 
-Nextjs dev server + Cypress test viewer + nock
+Nextjs dev server + Cypress test viewer without nock
 
 ```
-npm run cy:nock
+npm run cy:nockless
 ```
 
 Run cypress tests headless

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "next build",
     "build-and-start": "next build && next start",
-    "cy": "start-server-and-test dev http://localhost:3000 cypress:open",
-    "cy:nock": "cypress open --env nock=true",
+    "cy": "cypress open --env nock=true",
+    "cy:nockless": "start-server-and-test dev http://localhost:3000 cypress:open",
     "cypress:open": "cypress open",
     "cypress:run": "cypress run",
     "cypress:run:fast": "cypress run --env nock=true --spec=cypress/tests/integration/**/*.cy.js --config video=false",


### PR DESCRIPTION
# Description

- update cypress test command to run nock by default

Fixes @keyy123 struggles with `npm run cy` :wink: 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist:

- [x] I have made corresponding changes to the documentation
