### PR TITLE
fix(admin/theme): reset typography vals correctly

### DIFF
--- a/src/components/playground/TypographyInput.js
+++ b/src/components/playground/TypographyInput.js
@@ -160,6 +160,10 @@ function FontFamily(props) {
     setPropByPath(path, userInput);
   };
 
+  useEffect(() => {
+    setValue(() => getPropByPath(path));
+  });
+
   return (
     <>
       <FormControl

--- a/src/components/playground/TypographyInput.js
+++ b/src/components/playground/TypographyInput.js
@@ -132,7 +132,7 @@ function FontFamilyWeightElm({ label, path, fontValue }) {
 
 function FontFamily(props) {
   const { label, path } = props;
-  const { getPropByPath } = usePlaygroundTheme();
+  const { theme, getPropByPath } = usePlaygroundTheme();
   const { setPropByPath } = usePlaygroundUtils();
   const [value, setValue] = useState(() => getPropByPath(path));
   const [fonts] = usePlaygroundFonts();
@@ -162,7 +162,7 @@ function FontFamily(props) {
 
   useEffect(() => {
     setValue(() => getPropByPath(path));
-  });
+  }, [theme]);
 
   return (
     <>


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

Fixes #1353 
Added useEffect statement to reactively update TypographyInput when MUI theme was changed. 

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |

[before](https://user-images.githubusercontent.com/48111116/213859084-516a2d71-c696-486c-b4be-3641e89959eb.PNG)
[after](https://user-images.githubusercontent.com/48111116/213859091-defe7d53-2905-4350-9d80-2a7ae98ad9ce.PNG)

# How Has This Been Tested?

- [x ] Cypress integration
- [ x] Cypress component tests

# Checklist:

- [x ] I have performed a self-review of my own code
- [ x] My changes generate no new warnings
