### PR TITLE
Add time elements on organization page #1501

### DIFF
--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -162,7 +162,9 @@ export default function Organization(props) {
                   <>
                     Organization since
                     <time dateTime={organization?.created_at}>
-                      {moment(organization?.created_at).format('MMMM DD, YYYY')}
+                      {` ${moment(organization?.created_at).format(
+                        'MMMM DD, YYYY',
+                      )}`}
                     </time>
                   </>
                 }


### PR DESCRIPTION
# Description

Wrap timestamp data inside the time element on the organization page.

Fixes #1501 

