### PR TITLE
feat: set tree species section with ul and li tags #1496

### DIFF
--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -1,3 +1,4 @@
+
 import { Box, Divider, Grid, Typography, Avatar } from '@mui/material';
 import Portal from '@mui/material/Portal';
 import log from 'loglevel';
@@ -158,16 +159,9 @@ export default function Organization(props) {
             <Box sx={{ mt: 2 }}>
               <Info
                 iconURI={CalendarIcon}
-                info={
-                  <>
-                    Organization since
-                    <time dateTime={organization?.created_at}>
-                      {` ${moment(organization?.created_at).format(
-                        'MMMM DD, YYYY',
-                      )}`}
-                    </time>
-                  </>
-                }
+                info={`Organization since ${moment(
+                  organization?.created_at,
+                ).format('MMMM DD, YYYY')}`}
               />
             </Box>
             <Box sx={{ mt: 2 }}>
@@ -210,16 +204,9 @@ export default function Organization(props) {
               <Box sx={{ mt: 2 }}>
                 <Info
                   iconURI={CalendarIcon}
-                  info={
-                    <>
-                      Organization since
-                      <time dateTime={organization?.created_at}>
-                        {` ${moment(organization?.created_at).format(
-                          'MMMM DD, YYYY',
-                        )}`}
-                      </time>
-                    </>
-                  }
+                  info={`Organization since ${moment().format(
+                    'MMMM DD, YYYY',
+                  )}`}
                 />
               </Box>
               <Box sx={{ mt: 2 }}>
@@ -356,24 +343,20 @@ export default function Organization(props) {
             >
               Species of trees planted
             </Typography>
-            <Box
-              sx={{
-                mt: [5, 10],
-              }}
-            >
-              {organization?.species?.species?.map((s) => (
-                <React.Fragment key={s.name}>
-                  <TreeSpeciesCard
-                    name={s.name}
-                    subTitle={s.desc || '---'}
-                    count={s.total}
-                  />
-                  <Box sx={{ mt: [2, 4] }} />
-                </React.Fragment>
-              ))}
-            </Box>
-            {(!organization?.species?.species ||
-              organization?.species?.species.length === 0) && (
+            {organization?.species?.species?.length ? (
+              <Box component="ul" sx={{ mt: [5, 10], listStyle: 'none', p: 0 }}>
+                {organization?.species?.species?.map((s) => (
+                  <li key={s.name}>
+                    <TreeSpeciesCard
+                      name={s.name}
+                      subTitle={s.desc || '---'}
+                      count={s.total}
+                    />
+                    <Box sx={{ mt: [2, 4] }} />
+                  </li>
+                ))}
+              </Box>
+            ) : (
               <Typography variant="h5">NO DATA YET</Typography>
             )}
           </Box>
@@ -418,14 +401,22 @@ export default function Organization(props) {
                 location: 'Addis Ababa, Ethisa',
               },
             ].map((planter, i) => ( */}
-          {organization?.associatedPlanters?.planters
-            ?.sort((e1) => (e1.about ? -1 : 1))
-            .map((planter, i) => (
-              <Box sx={{ mt: [6, 12] }} key={planter.name}>
-                <PlanterQuote planter={planter} reverse={i % 2 !== 0} />
-              </Box>
-            ))}
+          {organization?.associatedPlanters?.planters?.length ? (
+            <Box component="ul" sx={{ mt: [6, 12], listStyle: 'none', p: 0 }}>
+              {organization?.associatedPlanters?.planters
+                ?.sort((e1) => (e1.about ? -1 : 1))
+                .map((planter, i) => (
+                  <li key={planter.name}>
+                    <PlanterQuote planter={planter} reverse={i % 2 !== 0} />
+                    <Box sx={{ mt: [6, 12] }} />
+                  </li>
+                ))}
+            </Box>
+          ) : (
+            <Typography variant="h5">NO DATA YET</Typography>
+          )}
         </Box>
+
         <Box
           sx={{
             px: [24 / 8, 24 / 4],
@@ -433,51 +424,47 @@ export default function Organization(props) {
           }}
         >
           <Divider varian="fullwidth" />
-          <article>
-            <Typography
-              sx={{
-                mt: [80 / 8, 80 / 4],
+          <Typography
+            sx={{
+              mt: [80 / 8, 80 / 4],
+            }}
+            variant="h4"
+          >
+            About the Organization
+          </Typography>
+          <Typography variant="body2" mt={7}>
+            <Box
+              component="span"
+              dangerouslySetInnerHTML={{
+                __html: marked.parse(organization.about || 'NO DATA YET'),
               }}
-              variant="h4"
-            >
-              About the Organization
-            </Typography>
-            <Typography variant="body2" mt={7}>
-              <Box
-                component="span"
-                dangerouslySetInnerHTML={{
-                  __html: marked.parse(organization.about || 'NO DATA YET'),
-                }}
-              />
-            </Typography>
-          </article>
-          <article>
-            <Typography variant="h4" sx={{ mt: { xs: 10, md: 16 } }}>
-              Mission
-            </Typography>
-            <Typography variant="body2" mt={7}>
-              <Box
-                component="span"
-                sx={{
-                  fontFamily: 'Lato',
-                  fontWeight: 400,
-                  fontSize: '20px',
-                  lineHeight: '28px',
-                  letterSpacing: '0.04em',
-                }}
-                dangerouslySetInnerHTML={{
-                  __html: marked.parse(organization.mission || 'NO DATA YET'),
-                }}
-              />
-            </Typography>
-          </article>
+            />
+          </Typography>
+          <Typography variant="h4" sx={{ mt: { xs: 10, md: 16 } }}>
+            Mission
+          </Typography>
+          <Typography variant="body2" mt={7}>
+            <Box
+              component="span"
+              sx={{
+                fontFamily: 'Lato',
+                fontWeight: 400,
+                fontSize: '20px',
+                lineHeight: '28px',
+                letterSpacing: '0.04em',
+              }}
+              dangerouslySetInnerHTML={{
+                __html: marked.parse(organization.mission || 'NO DATA YET'),
+              }}
+            />
+          </Typography>
           <Divider
             varian="fullwidth"
             sx={{
               mt: [10, 20],
             }}
           />
-
+          <ImpactSection />
           <Box sx={{ height: 80 }} />
         </Box>
       </Box>


### PR DESCRIPTION
# Description

[comment]: # The sections 'Species of trees planted' and 'Hired Planters' have been converted into unordered lists using list items (li elements). The default styling of the lists has been removed by setting the listStyle and p properties to none and 0, respectively. #1496

Fixes # 1496

## Improvement. SEO

[comment]: # 'Please delete options that are not relevant.'

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| "screenshot before" | "screenshot after" |

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
