### PR TITLE
Feat:  cwm select input for font weight

### DIFF
--- a/src/components/playground/FontWeightInput.js
+++ b/src/components/playground/FontWeightInput.js
@@ -1,25 +1,16 @@
 import { RestartAlt } from '@mui/icons-material';
 import {
   Box,
-  InputAdornment,
-  CircularProgress,
   InputLabel,
   Tooltip,
   FormControl,
-  Input,
   FormHelperText,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import { useState, useEffect, useCallback, memo } from 'react';
-import {
-  usePlaygroundUtils,
-  usePlaygroundFonts,
-  usePlaygroundTheme,
-} from 'hooks/contextHooks';
+import { usePlaygroundUtils, usePlaygroundFonts, usePlaygroundTheme } from 'hooks/contextHooks';
 import { useDefaultValue } from 'hooks/cwmHooks';
-import {
-  propRules,
-  fontWeightNameToValue,
-} from 'models/themePlaygroundOptions';
 import { loadFonts } from 'models/utils';
 
 function FontWeightInput({ prop, pathToProp, propName }) {
@@ -46,21 +37,7 @@ function FontWeightInput({ prop, pathToProp, propName }) {
         return setError('Please add a font first');
       }
 
-      // handle case of not a convertable string weight
-      // 'bolder', 'lighter', 'inherit' ....
-      if (!(userInput in fontWeightNameToValue)) {
-        setPropByPath(`${pathToProp}.${propName}`, userInput);
-        return true;
-      }
-
-      const isWeightValueNumber = Number.isNaN(Number(userInput)) === false;
-
-      // convert the string weight to an number
-      // 'bold' & 'normal'
-      let weightToLoad = userInput;
-      if (isWeightValueNumber === false) {
-        weightToLoad = fontWeightNameToValue[userInput];
-      }
+      const weightToLoad = userInput;
 
       setLoading(true);
       loadFonts([`${fontFamily}:${weightToLoad}`]).then((fontLoaded) => {
@@ -89,12 +66,7 @@ function FontWeightInput({ prop, pathToProp, propName }) {
   const handleChange = (e) => {
     const userInput = e.target.value;
     setValue(userInput);
-    if (!propRules[propName].test(userInput)) {
-      setError(`Invalid ${prop.displayText}`);
-      return;
-    }
 
-    e.target.blur();
     loadWeight(userInput);
     setError('');
   };
@@ -115,15 +87,25 @@ function FontWeightInput({ prop, pathToProp, propName }) {
           </Tooltip>
         </Box>
       </InputLabel>
-      <Input
-        value={value}
-        onChange={handleChange}
-        endAdornment={
-          <InputAdornment position="end">
-            {loading ? <CircularProgress size="1.5rem" /> : null}
-          </InputAdornment>
-        }
-      />
+      <Select value={value} onChange={handleChange}>
+        {prop.options?.map((data) => (
+          <MenuItem
+            value={data.value}
+            key={`fw-selector-menuitem-${data.value}`}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                flex: 1,
+              }}
+            >
+              <span>{data.label}</span>
+            </Box>
+          </MenuItem>
+        ))}
+      </Select>
       <FormHelperText>{error || `Load ${prop.displayText}.`}</FormHelperText>
     </FormControl>
   );


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

Fixes #1636 

* Replace text input with select input
* Removed unnecessary code from handleChange and loadWeight function after addition of select input

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| ![image](https://github.com/Greenstand/treetracker-web-map-client/assets/68511458/5d6a5e18-64ad-48cc-9194-7a148e0dab74) | ![image](https://github.com/Greenstand/treetracker-web-map-client/assets/68511458/7d940f05-a4c4-416e-ad32-b021e44d6f6e) |

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
