### PR TITLE
refactor: renames tree info to capture info and removes unused tags

### DIFF
--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -612,7 +612,7 @@ export default function Tree({
             },
           ]}
         >
-          Tree Info
+          Capture Info
         </Typography>
         <TagList>
           <TreeTag
@@ -649,22 +649,6 @@ export default function Tree({
             disabled={tree.species_name === null}
             subtitle={tree.species_desc === null ? null : 'click to learn more'}
             link={tree.species_desc === null ? null : tree.species_desc}
-          />
-          <TreeTag
-            TreeTagValue={
-              tree.gps_accuracy === null ? 'unknown' : tree.gps_accuracy
-            }
-            title="GPS Accuracy"
-            icon={<Icon icon={AccuracyIcon} />}
-            disabled={tree.gps_accuracy === null}
-          />
-          <TreeTag
-            TreeTagValue={
-              tree.morphology === null ? 'unknown' : tree.morphology
-            }
-            title="Morphology"
-            icon={<Icon icon={HubIcon} />}
-            disabled={tree.morphology === null}
           />
           <TreeTag
             TreeTagValue={

--- a/src/pages/v2/captures/[captureid].js
+++ b/src/pages/v2/captures/[captureid].js
@@ -615,7 +615,7 @@ export default function Capture({
             },
           ]}
         >
-          Tree Info
+          Capture Info
         </Typography>
         <TagList>
           <TreeTag
@@ -650,22 +650,6 @@ export default function Capture({
             disabled={tree.species_name === null}
             subtitle={tree.species_desc === null ? null : 'click to learn more'}
             link={tree.species_desc === null ? null : tree.species_desc}
-          />
-          <TreeTag
-            TreeTagValue={
-              tree.gps_accuracy === null ? 'unknown' : tree.gps_accuracy
-            }
-            title="GPS Accuracy"
-            icon={<Icon icon={AccuracyIcon} />}
-            disabled={tree.gps_accuracy === null}
-          />
-          <TreeTag
-            TreeTagValue={
-              tree.morphology === null ? 'unknown' : tree.morphology
-            }
-            title="Morphology"
-            icon={<Icon icon={HubIcon} />}
-            disabled={tree.morphology === null}
           />
           <TreeTag
             TreeTagValue={


### PR DESCRIPTION
This is a refactor to rename Tree Info to Capture Info and removes the morphology and gps accuracy tags

Fixes # #1679 

## Type of change

- [x] This change requires a documentation update

Before:
![image](https://github.com/Greenstand/treetracker-web-map-client/assets/40811107/67de3e0a-02a9-4e86-8bc0-d3285f3416ca)


After:
![image](https://github.com/Greenstand/treetracker-web-map-client/assets/40811107/d2545859-8600-4c6e-a02f-0e214678d30c)


# How Has This Been Tested?

- [x] Cypress integration
- [x] Cypress component tests
- [x] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
