### PR TITLE
Theme from os

### DIFF
--- a/src/context/themeContext.js
+++ b/src/context/themeContext.js
@@ -2,8 +2,8 @@ import { ThemeProvider, createTheme } from '@mui/material/styles';
 import axios from 'axios';
 import log from 'loglevel';
 import React from 'react';
-import { useLocalStorage } from '../hooks/globalHooks';
-import { loadFonts, convertFontObjToFontArr } from '../models/utils';
+import { useLocalStorage } from 'hooks/globalHooks';
+import { loadFonts, convertFontObjToFontArr } from 'models/utils';
 
 export const CustomThemeContext = React.createContext({
   toggleColorMode: () => {},
@@ -344,7 +344,13 @@ const defaultLightTheme = buildTheme('light');
 const defaultDarkTheme = buildTheme('dark');
 
 export function CustomThemeProvider({ children }) {
-  const [mode, setMode] = useLocalStorage('theme', 'light');
+  let osTheme = 'light';
+  if (typeof window !== 'undefined') {
+    osTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+  }
+  const [mode, setMode] = useLocalStorage('theme', osTheme);
   const [theme, setTheme] = React.useState(
     mode === 'light' ? defaultLightTheme : defaultDarkTheme,
   );


### PR DESCRIPTION
# Description

This change will set the users theme from the OS preferences. If these preferences cannot be accessed then the application will default to the light theme.

The change should not break anything but it's a good idea to test it manually on someone else's machine before merging. To do so you need to delete the previous theme from Application -> Local Storage in dev tools.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Cypress integration
- [x] Cypress component tests
- [x] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
