### PR TITLE
fix: allow page to navigate back to valid url when bounds change

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -171,7 +171,10 @@ function MapComponent() {
           map,
           router,
         );
-        window.history.pushState('treetracker', '', path);
+        // changing the url in history state
+        // this allow website to load page back
+        const historyState = { ...window.history.state, url: path };
+        window.history.replaceState(historyState, '', path);
       });
     }
 


### PR DESCRIPTION
# Description

I have fixed the website that allows the page to navigate back to the valid URL instead of the previous bounds

Fixes #725 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Videos

[screen-capture.webm](https://github.com/Greenstand/treetracker-web-map-client/assets/81385914/4226689e-2973-4714-9bac-0fa215603409)

# How Has This Been Tested?

- [x] Cypress integration
- [x] Cypress component tests
- [x] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
