### PR TITLE
Fix: replace '\n' with '<br/>' for line breaks in wallet.about

### DIFF
--- a/src/pages/wallets/[walletid].js
+++ b/src/pages/wallets/[walletid].js
@@ -374,7 +374,9 @@ export default function Wallet(props) {
           sx={{ mt: [2.5, 5] }}
           variant="body2"
           dangerouslySetInnerHTML={{
-            __html: marked.parse(wallet.about || 'NO DATA YET'),
+            __html: marked.parse(
+              (wallet.about || 'NO DATA YET').replace(/\\n/g, '<br/>'),
+            ),
           }}
         />
         <Divider


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

Fixes # Fixes an issue where '\\\n' characters in wallet.about content were not rendered correctly as line breaks. Replaced '\\n' with '\<br>' tags to ensure proper line breaks in the rendered HTML content.

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [ ] Bug fix (non-breaking change which fixes an issue)

