### PR TITLE
fix: make share component accessible

### DIFF
--- a/src/components/Share.js
+++ b/src/components/Share.js
@@ -60,6 +60,14 @@ function Share(props) {
     setIsOpen(true);
   }
 
+  function onKeyDown(e) {
+    e.preventDefault();
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      handleClick();
+    }
+  }
+
   function handleClose() {
     setIsOpen(false);
   }
@@ -105,7 +113,17 @@ function Share(props) {
 
   return (
     <>
-      {icon && <Box onClick={handleClick}>{icon}</Box>}
+      {icon && (
+        <Box
+          onClick={handleClick}
+          role="button"
+          tabIndex="0"
+          aria-label="View sharing options"
+          onKeyDown={onKeyDown}
+        >
+          {icon}
+        </Box>
+      )}
       {!icon && (
         <IconButton onClick={handleClick}>
           <ShareIcon style={{ color: green[500] }} />
@@ -127,17 +145,17 @@ function Share(props) {
           zIndex: 9999,
         }}
       >
-        <DialogTitle
+        <Box
           sx={{
             p: 0,
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            display: 'flex',
           }}
         >
-          <Box
+          <DialogTitle
             sx={{
               p: 0,
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              display: 'flex',
             }}
           >
             <Typography
@@ -148,11 +166,16 @@ function Share(props) {
             >
               Share this link
             </Typography>
-            <IconButton className={classes.closeIcon} onClick={handleClose}>
-              <Close style={{ color: green[500] }} />
-            </IconButton>
-          </Box>
-        </DialogTitle>
+          </DialogTitle>
+          <IconButton
+            className={classes.closeIcon}
+            onClick={handleClose}
+            aria-label="Close"
+          >
+            <Close style={{ color: green[500] }} />
+          </IconButton>
+        </Box>
+
         <Box
           sx={{
             gap: 4,
@@ -161,16 +184,28 @@ function Share(props) {
             p: [2, 4],
           }}
         >
-          <CustomShareIcon handleOnClick={handleEmbed}>
+          <CustomShareIcon
+            handleOnClick={handleEmbed}
+            aria_label="Get embed code"
+          >
             <Code />
           </CustomShareIcon>
-          <CustomShareIcon handleOnClick={handleFaceBook}>
+          <CustomShareIcon
+            handleOnClick={handleFaceBook}
+            aria_label="Share on Facebook"
+          >
             <FacebookRoundedIcon />
           </CustomShareIcon>
-          <CustomShareIcon handleOnClick={handleTwitter}>
+          <CustomShareIcon
+            handleOnClick={handleTwitter}
+            aria_label="Share on Twitter"
+          >
             <TwitterIcon />
           </CustomShareIcon>
-          <CustomShareIcon mailString={mailString}>
+          <CustomShareIcon
+            mailString={mailString}
+            aria_label="Share over Email"
+          >
             <Email />
           </CustomShareIcon>
         </Box>
@@ -201,18 +236,20 @@ function Share(props) {
         </Box>
       </Dialog>
       <Dialog open={isEmbedOpen} onClose={handleEmbedClose}>
-        <DialogTitle>
-          <Grid container justifyContent="space-between" alignItems="center">
-            <Grid item xs={8}>
-              Embed Greenstand
-            </Grid>
-            <Grid item>
-              <IconButton onClick={handleEmbedClose} size="large">
-                <Close />
-              </IconButton>
-            </Grid>
+        <Grid container justifyContent="space-between" alignItems="center">
+          <Grid item xs={8}>
+            <DialogTitle>Embed Greenstand</DialogTitle>
           </Grid>
-        </DialogTitle>
+          <Grid item>
+            <IconButton
+              onClick={handleEmbedClose}
+              size="large"
+              aria-label="Close"
+            >
+              <Close />
+            </IconButton>
+          </Grid>
+        </Grid>
         <TextField
           id="EmbedCode"
           multiline

--- a/src/components/common/CustomShareIcon.js
+++ b/src/components/common/CustomShareIcon.js
@@ -1,6 +1,11 @@
 import { IconButton } from '@mui/material';
 
-function CustomShareIcon({ handleOnClick, children, mailString }) {
+function CustomShareIcon({
+  handleOnClick,
+  children,
+  mailString,
+  aria_label = '',
+}) {
   const button = (
     <IconButton
       sx={{
@@ -17,6 +22,7 @@ function CustomShareIcon({ handleOnClick, children, mailString }) {
         },
       }}
       onClick={handleOnClick}
+      aria-label={aria_label}
     >
       {children}
     </IconButton>


### PR DESCRIPTION
# Description

- Share button can now be accessed by keyboard
- Added label to buttons so screen readers announce what the button is for
- Close option (x icon) on dialog can now be accessed by keyboard

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="627" alt="before_1" src="https://github.com/Greenstand/treetracker-web-map-client/assets/53157755/714ded4e-b74c-42a8-a3ae-6de67a0e4ff5">  | <img width="569" alt="after_1" src="https://github.com/Greenstand/treetracker-web-map-client/assets/53157755/ef877a73-0ae6-4fd3-b730-d98de3da79b5"> |



# Checklist:

- [x] I have performed a self-review of my own code

