### PR TITLE
fix the issue 1747: can't goto bounds in top page

### DIFF
--- a/src/pages/top.js
+++ b/src/pages/top.js
@@ -3,28 +3,30 @@ import Portal from '@mui/material/Portal';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import log from 'loglevel';
+import { useRouter } from 'next/router';
 import React from 'react';
+import FeaturedPlantersSlider from 'components/FeaturedPlantersSlider';
+import FeaturedTreesSlider from 'components/FeaturedTreesSlider';
 import HeadTag from 'components/HeadTag';
+import LeaderBoard from 'components/LeaderBoard';
 import SearchButton from 'components/SearchButton';
+import TagChips from 'components/TagChips';
+import Crumbs from 'components/common/Crumbs';
+import Icon from 'components/common/CustomIcon';
+import Filter from 'components/common/Filter';
+import { useFullscreen } from 'hooks/globalHooks';
+import Search from 'images/search.svg';
+import { useMapContext } from 'mapContext';
 import { getCountryLeaderboard, getFeaturedTrees } from 'models/api';
-import FeaturedPlantersSlider from '../components/FeaturedPlantersSlider';
-import FeaturedTreesSlider from '../components/FeaturedTreesSlider';
-import LeaderBoard from '../components/LeaderBoard';
-// import SearchFilter from '../components/SearchFilter';
-import TagChips from '../components/TagChips';
-import Crumbs from '../components/common/Crumbs';
-import Icon from '../components/common/CustomIcon';
-import Filter from '../components/common/Filter';
-import { useFullscreen } from '../hooks/globalHooks';
-import Search from '../images/search.svg';
-import { useMapContext } from '../mapContext';
-import * as utils from '../models/utils';
+import * as pathResolver from 'models/pathResolver';
+import * as utils from 'models/utils';
 
 function Top(props) {
   log.warn('props top:', props);
   const { trees, planters, countries, organizations, wallets } = props;
   // use map context to get the map
   const { map } = useMapContext();
+  const router = useRouter();
   const isFullscreen = useFullscreen();
 
   const continentTags = [
@@ -47,6 +49,14 @@ function Top(props) {
     async function reload() {
       if (mapContext.map) {
         await mapContext.map.setFilters({});
+        const bounds = pathResolver.getBounds(router);
+        if (bounds) {
+          log.warn('goto bounds found in url');
+          await mapContext.map.gotoBounds(bounds);
+        } else {
+          log.warn('goto global view');
+          await map.gotoView(0, 0, 2);
+        }
       }
     }
     reload();


### PR DESCRIPTION
# Description

[comment]: Fix the  issue #1747: can not jump to bounds on the first view of the top page . Add bounds detection code to top page. Also, I strongly recommend that we should implement the goto function in a shared library rather than in each file just like that:
<img width="432" alt="image" src="https://github.com/Greenstand/treetracker-web-map-client/assets/6525061/48ab5464-3c12-4deb-bf58-0504afa563a2">
which may increase the complexity in our project.

Fixes # 1747

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| ![Before Image](https://github.com/Greenstand/treetracker-web-map-client/assets/6525061/d161ad0d-2089-449f-95e2-24fa0b436e32) | ![After Image](https://github.com/Greenstand/treetracker-web-map-client/assets/6525061/08436ea6-6efe-467f-ae2f-912f63ccd0c0) |


# How Has This Been Tested?

- [x] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
