### PR TITLE
feat: add postMessage method to send message to react native webview

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -72,7 +72,14 @@ function MapComponent() {
 
   async function handleClickTree(tree) {
     log.warn('click tree:', tree);
-    window.ReactNativeWebView?.postMessage(JSON.stringify(tree));
+    if (window.ReactNativeWebView) {
+      log.debug('react native');
+      window.ReactNativeWebView?.postMessage(JSON.stringify(tree));
+    }
+    if (window.parent) {
+      log.debug('window.parent');
+      window.parent.postMessage(JSON.stringify(tree), '*');
+    }
 
     const wholeTree = await getTreeById(tree.id).catch((err) => log.warn(err));
     const result = pathResolver.getPathWhenClickTree(

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -72,10 +72,7 @@ function MapComponent() {
 
   async function handleClickTree(tree) {
     log.warn('click tree:', tree);
-    if (window.parent) {
-      log.warn('DEMO:ok message parent');
-      window.parent.postMessage(JSON.stringify(tree), '*');
-    }
+    window.ReactNativeWebView?.postMessage(JSON.stringify(tree));
 
     const wholeTree = await getTreeById(tree.id).catch((err) => log.warn(err));
     const result = pathResolver.getPathWhenClickTree(


### PR DESCRIPTION
# Description

# 'Added postMessage method inside handleClickTree function to send tree object JSON string data to react native webview.'

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![image](https://github.com/Greenstand/treetracker-web-map-client/assets/61099792/69fdfab1-191a-4951-b52a-f8a7c3168438)

# How Has This Been Tested?

Change tested by imbedding the web map client into react native webview component.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
