### PR TITLE
fix: handle api 404 error to display data properly

### DIFF
--- a/src/models/api.js
+++ b/src/models/api.js
@@ -10,10 +10,10 @@ export async function getFeaturedGrowers() {
     const res = await axios.get(url);
     const data = await res.data;
     log.warn('url:', url, 'took:', Date.now() - begin);
-    return data.grower_accounts;
+    return data.grower_accounts || [];
   } catch (err) {
-    log.error(err.message);
-    throw err;
+    log.error('Error in getFeaturedGrowers:', err.message);
+    return [];
   }
 }
 
@@ -24,10 +24,10 @@ export async function getCaptures() {
     const res = await axios.get(url);
     const data = await res.data;
     log.warn('url:', url, 'took:', Date.now() - begin);
-    return data.captures;
+    return data.captures || [];
   } catch (err) {
-    log.error(err.message);
-    throw err;
+    log.error('Error in getCaptures:', err.message);
+    return [];
   }
 }
 
@@ -70,6 +70,20 @@ export async function getCountryLeaderboard() {
   } catch (err) {
     log.error(err.message);
     throw err;
+  }
+}
+
+export async function getOrganizations() {
+  try {
+    const url = apiPaths.featuredOrganizations;
+    const begin = Date.now();
+    const res = await axios.get(url);
+    const data = await res.data;
+    log.warn('url:', url, 'took:', Date.now() - begin);
+    return data.organizations || [];
+  } catch (err) {
+    log.error('Error in getOrganizations:', err.message);
+    return [];
   }
 }
 
@@ -174,6 +188,20 @@ export async function getOrgLinks({
     ...(associated_organizations && { associatedOrganizations: associates }),
     ...(associated_planters && { associatedPlanters: associates }),
   };
+}
+
+export async function getWallets() {
+  try {
+    const url = apiPaths.featuredWallets;
+    const begin = Date.now();
+    const res = await axios.get(url);
+    const data = await res.data;
+    log.warn('url:', url, 'took:', Date.now() - begin);
+    return data.wallets || [];
+  } catch (err) {
+    log.error('Error in getWallets:', err.message);
+    return [];
+  }
 }
 
 export async function getWalletById(id) {

--- a/src/models/apiPaths.js
+++ b/src/models/apiPaths.js
@@ -22,6 +22,8 @@ const apiPaths = {
   filterSpeciesByWalletId: (id = '') =>
     urlJoin(host, `/species?wallet_id=${id}`),
   tokens: (id = '') => urlJoin(host, `/tokens/${id}`),
+  featuredOrganizations: urlJoin(host, '/organizations/featured'),
+  featuredWallets: urlJoin(host, '/wallets/featured'),
 };
 
 export default apiPaths;

--- a/src/pages/top.js
+++ b/src/pages/top.js
@@ -20,7 +20,8 @@ import {
   getCaptures,
   getCountryLeaderboard,
   getFeaturedGrowers,
-  getFeaturedTrees,
+  getOrganizations,
+  getWallets,
 } from 'models/api';
 import * as utils from 'models/utils';
 
@@ -250,24 +251,16 @@ function Top(props) {
   );
 }
 
-async function serverSideData(params) {
+async function serverSideData() {
   const [captures, countries, growers, organizations, wallets] =
     await Promise.all([
-      getCaptures(), //
+      getCaptures(),
       process.env.NEXT_PUBLIC_COUNTRY_LEADER_BOARD_DISABLED === 'true'
         ? []
         : getCountryLeaderboard(),
       getFeaturedGrowers(),
-      (async () => {
-        const data = await utils.requestAPI('/organizations/featured');
-        log.warn('organizations', data);
-        return data.organizations;
-      })(),
-      (async () => {
-        const data = await utils.requestAPI('/wallets/featured');
-        log.warn('wallets', data);
-        return data.wallets;
-      })(),
+      getOrganizations(),
+      getWallets(),
     ]);
   return {
     captures,
@@ -278,8 +271,8 @@ async function serverSideData(params) {
   };
 }
 
-const getStaticProps = utils.wrapper(async ({ params }) => {
-  const props = await serverSideData(params);
+const getStaticProps = utils.wrapper(async () => {
+  const props = await serverSideData();
   return {
     props,
     revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 30,


### PR DESCRIPTION
# Description

Fixes #1801

⛔️ Cause: when populating static props (captures, countries, growers, organizations, wallets) in `top.js`, if any of the 5 items got a 404 upon API request, the page renders a 404 not found because the field was not properly populated.

🧩 Solution: consolidate all API request functions into `src/models/api.js`, including error handling. When an API request failed, the function returns an empty array.

📝 Note: For now, API requests to `captures` and `growers` return 404, so the below error persists, and the frontend is only displaying `countries`, `organizations`, and `wallets` (please refer to the screenshot in the next section). I believe the investigation should continue on [treetracker-query-api](https://github.com/Greenstand/treetracker-query-api) in terms of fetching captures and featured growers. I've checked `/captures` and `/growers/featured` endpoints, neither of them are working.

<img width="565" alt="image" src="https://github.com/user-attachments/assets/b6dbab91-bacf-4b2d-a973-fb8897239e04">

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="735" alt="image" src="https://github.com/user-attachments/assets/6ba96689-5422-4fc0-97d9-711df63d0a00"> | <img width="735" alt="image" src="https://github.com/user-attachments/assets/657ede88-df39-4ffc-bc86-9b69397e5412"> |

# How Has This Been Tested?

- [x] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
