### PR TITLE
Fix: Ensure UUIDTag Component Handles Non-String UUID Values Safely

### DIFF
--- a/src/components/common/UUIDTag.cy.js
+++ b/src/components/common/UUIDTag.cy.js
@@ -1,0 +1,24 @@
+import UUIDTag from './UUIDTag';
+
+describe('UUIDTag', () => {
+  beforeEach(() => {
+    cy.viewport(500, 500);
+  });
+
+  it('renders correctly with a valid UUID string', () => {
+    const testId = '12345678';
+    cy.mount(<UUIDTag uuid={testId} />);
+    cy.contains('1234...5678').should('exist');
+  });
+
+  it('handles non-string UUID values gracefully', () => {
+    const testIdNonString = 12345678;
+    cy.mount(<UUIDTag uuid={testIdNonString} />);
+    cy.contains('1234...5678').should('exist');
+  });
+
+  it('displays a fallback for undefined UUID', () => {
+    cy.mount(<UUIDTag uuid={undefined} />);
+    cy.contains('...').should('exist');
+  });
+});

--- a/src/components/common/UUIDTag.js
+++ b/src/components/common/UUIDTag.js
@@ -2,12 +2,14 @@ import { Box, Tooltip, Typography } from '@mui/material';
 import { useClipboard } from 'hooks/globalHooks';
 
 function UUIDTag({ uuid, sx }) {
-  const formattedId = `${uuid.slice(0, 4)}...${uuid.slice(
-    uuid.length - 4,
-    uuid.length,
+  const id = typeof uuid === 'string' ? uuid : String(uuid || '');
+
+  const formattedId = `${id.slice(0, 4)}...${id.slice(
+    id.length - 4,
+    id.length,
   )}`;
 
-  const { onCopy, hasCopied } = useClipboard(uuid);
+  const { onCopy, hasCopied } = useClipboard(id);
 
   const title = (
     <>


### PR DESCRIPTION
# Description

- Added a type check for uuid, converting it to a string or an empty string if uuid is undefined or not a string, and confirmed that `.slice()` operates correctly without causing runtime errors.
- Added a cypress component test for `UUIDTag`

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

[comment]: # 'Please include screenshots of your changes if relevant.'

|       Before        |       After        |
| :-----------------: | :----------------: |
| <img width="1231" alt="Screenshot 2024-10-28 at 6 51 39 PM" src="https://github.com/user-attachments/assets/51df5239-3385-4aa8-9582-0d582273d239"> | <img width="1776" alt="image" src="https://github.com/user-attachments/assets/de0ff218-3e4a-4c7e-9537-75a1461c283e"> |

# How Has This Been Tested?

- [x] Cypress integration
- [x] Cypress component tests
- [ ] Jest unit tests

<img width="701" alt="image" src="https://github.com/user-attachments/assets/371f8f08-8dfd-4819-b729-d31d44700a9c">
<img width="445" alt="image" src="https://github.com/user-attachments/assets/ad543089-e652-4fb2-940c-c034c43d816a">


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
