### PR TITLE
fix: prevent keyword=undefined from appearing in navigation URLs

### DIFF
--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -577,9 +577,15 @@ export default function Tree({
               entityType="Planting Organization"
               buttonText="Meet the Organization"
               cardImageSrc={organization?.logo_url || imagePlaceholder}
-              link={`/organizations/${
-                organization.id
-              }?keyword=${nextExtraKeyword}${isEmbed ? '&embed=true' : ''}`}
+              link={`/organizations/${organization.id}${
+                nextExtraKeyword
+                  ? `?keyword=${nextExtraKeyword}`
+                  : ''
+              }${
+                isEmbed
+                  ? `${nextExtraKeyword ? '&' : '?'}embed=true`
+                  : ''
+              }`}
             />
           </Box>
         )}
@@ -594,8 +600,14 @@ export default function Tree({
             buttonText="Meet the Planter"
             cardImageSrc={planter?.image_url || imagePlaceholder}
             rotation={planter?.image_rotation}
-            link={`/planters/${planter.id}?keyword=${nextExtraKeyword}${
-              isEmbed ? '&embed=true' : ''
+            link={`/planters/${planter.id}${
+              nextExtraKeyword
+                ? `?keyword=${nextExtraKeyword}`
+                : ''
+            }${
+              isEmbed
+                ? `${nextExtraKeyword ? '&' : '?'}embed=true`
+                : ''
             }`}
           />
         </Box>

--- a/src/pages/v2/captures/[captureid].js
+++ b/src/pages/v2/captures/[captureid].js
@@ -579,8 +579,14 @@ export default function Capture({
               buttonText="Meet the Organization"
               cardImageSrc={logo_url || imagePlaceholder}
               // TODO: this wont work until organizationsV2 page is completed
-              link={`/stakeholder/stakeholders/${id}?keyword=${nextExtraKeyword}${
-                isEmbed ? '&embed=true' : ''
+              link={`/stakeholder/stakeholders/${id}${
+                nextExtraKeyword
+                  ? `?keyword=${nextExtraKeyword}`
+                  : ''
+              }${
+                isEmbed
+                  ? `${nextExtraKeyword ? '&' : '?'}embed=true`
+                  : ''
               }`}
             />
           </Box>
@@ -597,8 +603,14 @@ export default function Capture({
             cardImageSrc={grower?.image_url || imagePlaceholder}
             rotation={grower?.image_rotation}
             // TODO: this wont work until growers page is completed
-            link={`/grower-accounts/${grower.id}?keyword=${nextExtraKeyword}${
-              isEmbed ? '&embed=true' : ''
+            link={`/grower-accounts/${grower.id}${
+              nextExtraKeyword
+                ? `?keyword=${nextExtraKeyword}`
+                : ''
+            }${
+              isEmbed
+                ? `${nextExtraKeyword ? '&' : '?'}embed=true`
+                : ''
             }`}
           />
         </Box>


### PR DESCRIPTION
Fixes #1813. When you click "Meet the Organization" or "Meet the Planter" from a tree page, the URL gets `keyword=undefined` stuck in it because the template literal always interpolates the keyword param even when it doesn't exist in the current URL. Now keyword is only added when it actually has a value, and the separator between query params adjusts correctly. Four spots fixed across two files, same code style, nothing else touched.

<!-- DCCE:AI-BEGIN
{
  "dcceVersion": "0.1",
  "id": "d9ec059f-ed90-4ee5-ad5b-6497d077dab2",
  "contentType": "pr_description",
  "ai": {
    "intent": "Remove keyword=undefined from navigation URLs when keyword query param is absent",
    "scope": "4 link props in 2 page components",
    "testing": "Manual: visit /trees/8253212, click Meet the Organization, verify no keyword=undefined in URL. Test with ?keyword=test to verify forwarding. Test with ?embed=true for separator logic.",
    "issue": "#1813",
    "type": "bug_fix",
    "root_cause": "Template literal in link prop unconditionally interpolates nextExtraKeyword (from router.query.keyword). When no keyword query param exists in current URL, value is undefined, producing keyword=undefined.",
    "files_changed": [
      "src/pages/trees/[treeid].js",
      "src/pages/v2/captures/[captureid].js"
    ],
    "locations": [
      {"file": "[treeid].js", "lines": "580-588", "component": "Organization InformationCard1 link"},
      {"file": "[treeid].js", "lines": "603-611", "component": "Planter InformationCard1 link"},
      {"file": "[captureid].js", "lines": "582-590", "component": "Stakeholder InformationCard1 link"},
      {"file": "[captureid].js", "lines": "606-614", "component": "Grower InformationCard1 link"}
    ],
    "fix": "Conditionally append keyword param only when truthy. Adjust separator (? vs &) for embed param based on keyword presence.",
    "url_matrix": {
      "no_params": "/path/id",
      "keyword_only": "/path/id?keyword=abc",
      "embed_only": "/path/id?embed=true",
      "both": "/path/id?keyword=abc&embed=true"
    },
    "backward_compatible": true,
    "breaking_changes": false
  },
  "provenance": {
    "actor": "ai",
    "tool": "M7 MCP",
    "model": "claude-4.6-opus",
    "generatedAt": "2026-02-09T16:01:52.714Z"
  }
}
DCCE:AI-END -->