### PR TITLE
fix: preserve wallet context for email-style wallet IDs (#1795)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,7 @@ module.exports = {
         destination: '/trees/:treeId(\\d{1,})',
       },
       {
-        source: '/wallets/:walletId([0-9a-zA-Z-]{1,})/tokens/:tokenId(.{36})',
+        source: '/wallets/:walletId([^/]+)/tokens/:tokenId(.{36})',
         destination: '/tokens/:tokenId([a-z0-9-]{36})',
       },
       {
@@ -34,7 +34,7 @@ module.exports = {
         destination: '/?map=:map_name',
       },
       {
-        source: '/wallets/:walletId([0-9a-zA-Z-]{1,})/tokens',
+        source: '/wallets/:walletId([^/]+)/tokens',
         destination: '/tokens/idfromquery',
       },
     ];

--- a/src/models/pathResolver.js
+++ b/src/models/pathResolver.js
@@ -2,10 +2,10 @@ import log from 'loglevel';
 import * as utils from './utils';
 
 const MAP_URL_PATTERN =
-  /^(\/(planters|organizations|wallets)\/([a-z0-9-]+))?(\/(trees|tokens)\/([a-z0-9-]+))?(\?.*)?$/;
+  /^(\/(planters|organizations|wallets)\/([^/?]+))?(\/(trees|tokens)\/([^/?]+))?(\?.*)?$/;
 // v2 api pattern
 const MAP_URL_PATTERNV2 =
-  /^(\/v2\/(planters|organizations|wallets)\/([a-z0-9-]+))?(\/v2\/(trees|tokens|captures)\/([a-z0-9-]+))?(\?.*)?$/;
+  /^(\/v2\/(planters|organizations|wallets)\/([^/?]+))?(\/v2\/(trees|tokens|captures)\/([^/?]+))?(\?.*)?$/;
 
 // 1: (/planters/1234)
 // 2: (planters)
@@ -16,7 +16,7 @@ const MAP_URL_PATTERNV2 =
 // 7: (?embed=true&timeline=true)
 
 // '/wallets/1f2a0862-66d1-4b42-8216-5a5cb9c6eca5/tokens?tree_id=95614',
-const MAP_URL_PATTERN_2 = /^\/wallets\/([a-z0-9-]+)\/tokens$/;
+const MAP_URL_PATTERN_2 = /^\/wallets\/([^/?]+)\/tokens$/;
 
 function getPathWhenClickTree(
   tree,
@@ -72,7 +72,7 @@ function getPathWhenClickTree(
       }`;
     }
   } else {
-    const match2 = pathname.match(/^\/wallets\/([a-z0-9-]+)\/tokens$/);
+    const match2 = pathname.match(/^\/wallets\/([^/?]+)\/tokens$/);
     log.warn('match pattern 2', match2);
     if (match2) {
       pathnameResult = `/wallets/${match2[1]}/tokens`;
@@ -129,12 +129,13 @@ function getContext(router, options = {}) {
     return context;
   }
 
-  const match2 = pathname.match(/^\/wallets\/([a-z0-9-]+)\/tokens\?.*$/);
-  const context = {
-    name: 'wallets',
-    id: match2[1],
-  };
-  return context;
+  const match2 = pathname.match(/^\/wallets\/([^/?]+)\/tokens\?.*$/);
+  if (match2) {
+    return {
+      name: 'wallets',
+      id: match2[1],
+    };
+  }
 
   return null;
 }

--- a/src/models/pathResolver.test.js
+++ b/src/models/pathResolver.test.js
@@ -143,6 +143,50 @@ describe('Test pathResolver', () => {
       });
     });
 
+    it('click on /wallets/max.anders@plantamiarbol.com (email wallet ID)', () => {
+      const result = pathResolver.getPathWhenClickTree(
+        {
+          id: 14615,
+        },
+        {
+          pathname: '/wallets/max.anders@plantamiarbol.com',
+        },
+        {
+          query: {},
+        },
+      );
+
+      expect(result).toMatchObject({
+        pathname: '/wallets/max.anders@plantamiarbol.com/tokens',
+        query: {
+          tree_id: '14615',
+        },
+      });
+    });
+
+    it('click on /wallets/max.anders@plantamiarbol.com/tokens?tree_id=14615 (second click, email wallet)', () => {
+      const result = pathResolver.getPathWhenClickTree(
+        {
+          id: 14616,
+        },
+        {
+          pathname: '/wallets/max.anders@plantamiarbol.com/tokens',
+        },
+        {
+          query: {
+            tree_id: '14615',
+          },
+        },
+      );
+
+      expect(result).toMatchObject({
+        pathname: '/wallets/max.anders@plantamiarbol.com/tokens',
+        query: {
+          tree_id: '14616',
+        },
+      });
+    });
+
     it('click on /web-map-beta/demo/wallets/0cdf4219-869a-41ce-953a-a8421d8353f7/tokens with base', () => {
       const result = pathResolver.getPathWhenClickTree(
         {
@@ -260,6 +304,35 @@ describe('Test pathResolver', () => {
         name: 'wallets',
         id: '1f2a0862-66d1-4b42-8216-5a5cb9c6eca5',
       });
+    });
+
+    it('wallet context with email wallet ID', () => {
+      const result = pathResolver.getContext({
+        asPath:
+          '/wallets/max.anders@plantamiarbol.com/tokens?tree_id=123',
+      });
+      expect(result).toMatchObject({
+        name: 'wallets',
+        id: 'max.anders@plantamiarbol.com',
+      });
+    });
+
+    it('wallet context with email wallet ID and token', () => {
+      const result = pathResolver.getContext({
+        asPath:
+          '/wallets/max.anders@plantamiarbol.com/tokens/3a53e2a6-ac17-43a5-a3aa-31fd04786cba',
+      });
+      expect(result).toMatchObject({
+        name: 'wallets',
+        id: 'max.anders@plantamiarbol.com',
+      });
+    });
+
+    it('returns null for unrecognized path', () => {
+      const result = pathResolver.getContext({
+        asPath: '/some/unknown/path',
+      });
+      expect(result).toBeNull();
     });
 
     it('wallet context case2', () => {


### PR DESCRIPTION
When you pick a wallet with an email-style name like max.anders@plantamiarbol.com and click a tree on the map, the app was losing track of which wallet you were looking at and showing every token instead of just that wallet's tokens. Turns out the URL matching code only expected simple IDs with letters, numbers, and dashes — dots and @ signs weren't covered. Fixed the regex patterns in the path resolver and the Next.js rewrites so they handle any valid URL characters, also cleaned up a potential crash in getContext when it hit an unknown URL.

<!-- DCCE:AI-BEGIN
{
  "dcceVersion": "0.1",
  "id": "5b623450-10ca-480a-b708-8675b8d03c42",
  "contentType": "pr_description",
  "ai": {
    "issue": "#1795",
    "root_cause": "Regex patterns in pathResolver.js used [a-z0-9-]+ which does not match . and @ in email-style wallet IDs",
    "fix": "Replace [a-z0-9-]+ with [^/?]+ in 5 regex patterns across pathResolver.js, update 2 rewrite patterns in next.config.js from [0-9a-zA-Z-]{1,} to [^/]+, fix null safety in getContext()",
    "files_changed": [
      "src/models/pathResolver.js",
      "src/models/pathResolver.test.js",
      "next.config.js"
    ],
    "tests_added": 5,
    "tests_total": 21,
    "backward_compatible": true
  },
  "provenance": {
    "actor": "ai",
    "tool": "M7 MCP",
    "generatedAt": "2026-02-09T16:32:04.870Z"
  }
}
DCCE:AI-END -->

Made with [Cursor](https://cursor.com)