### PR TITLE
fix: enable markdown line break rendering in about sections (#1713)

### DIFF
--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -434,7 +434,9 @@ export default function Organization(props) {
               <Box
                 component="span"
                 dangerouslySetInnerHTML={{
-                  __html: marked.parse(organization.about || 'NO DATA YET'),
+                  __html: marked.parse(organization.about || 'NO DATA YET', {
+                    breaks: true,
+                  }),
                 }}
               />
             </Typography>
@@ -455,7 +457,9 @@ export default function Organization(props) {
                   letterSpacing: '0.04em',
                 }}
                 dangerouslySetInnerHTML={{
-                  __html: marked.parse(organization.mission || 'NO DATA YET'),
+                  __html: marked.parse(organization.mission || 'NO DATA YET', {
+                    breaks: true,
+                  }),
                 }}
               />
             </Typography>

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -489,7 +489,9 @@ export default function Planter(props) {
         >
           <span
             dangerouslySetInnerHTML={{
-              __html: marked.parse(planter.about || 'NO DATA YET'),
+              __html: marked.parse(planter.about || 'NO DATA YET', {
+                breaks: true,
+              }),
             }}
           />
         </Typography>

--- a/src/pages/wallets/[walletid].js
+++ b/src/pages/wallets/[walletid].js
@@ -374,7 +374,9 @@ export default function Wallet(props) {
           sx={{ mt: [2.5, 5] }}
           variant="body2"
           dangerouslySetInnerHTML={{
-            __html: marked.parse(wallet.about || 'NO DATA YET'),
+            __html: marked.parse(wallet.about || 'NO DATA YET', {
+              breaks: true,
+            }),
           }}
         />
         <Divider


### PR DESCRIPTION
The about sections on wallet, planter, and organization pages were rendering newline characters as spaces because marked.parse() was using default settings. The markdown parser treats single newlines as whitespace unless told otherwise, so text that should have been on separate lines was displayed as one continuous block. This fix adds the breaks option to all four marked.parse() calls across the three entity pages, which makes single newlines render as actual line breaks in the browser.

Closes #1713

<!--
{"dcce":"1.0","actor":"ai","model":"claude-4.6-opus","tool":"M7 MCP","changes":{"files":["src/pages/wallets/[walletid].js","src/pages/planters/[planterid].js","src/pages/organizations/[organizationid].js"],"lines_changed":16,"type":"bugfix"},"root_cause":"marked.parse() called without breaks:true option, single newlines in about text collapsed to spaces","fix":"added {breaks:true} to all 4 marked.parse() calls","verified":{"html_passthrough":true,"markdown_links":true,"empty_fallback":true,"newline_rendering":true},"risk":"minimal","rollback":"git revert"}
-->

Made with [Cursor](https://cursor.com)