### PR TITLE
fix: remove keyword=undefined from entity links (#1813)

### DIFF
--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -579,7 +579,7 @@ export default function Tree({
               cardImageSrc={organization?.logo_url || imagePlaceholder}
               link={`/organizations/${
                 organization.id
-              }?keyword=${nextExtraKeyword}${isEmbed ? '&embed=true' : ''}`}
+              }${nextExtraKeyword ? `?keyword=${nextExtraKeyword}${isEmbed ? '&embed=true' : ''}` : isEmbed ? '?embed=true' : ''}`}
             />
           </Box>
         )}
@@ -594,9 +594,7 @@ export default function Tree({
             buttonText="Meet the Planter"
             cardImageSrc={planter?.image_url || imagePlaceholder}
             rotation={planter?.image_rotation}
-            link={`/planters/${planter.id}?keyword=${nextExtraKeyword}${
-              isEmbed ? '&embed=true' : ''
-            }`}
+            link={`/planters/${planter.id}${nextExtraKeyword ? `?keyword=${nextExtraKeyword}${isEmbed ? '&embed=true' : ''}` : isEmbed ? '?embed=true' : ''}`}
           />
         </Box>
         <Typography

--- a/src/pages/v2/captures/[captureid].js
+++ b/src/pages/v2/captures/[captureid].js
@@ -579,9 +579,7 @@ export default function Capture({
               buttonText="Meet the Organization"
               cardImageSrc={logo_url || imagePlaceholder}
               // TODO: this wont work until organizationsV2 page is completed
-              link={`/stakeholder/stakeholders/${id}?keyword=${nextExtraKeyword}${
-                isEmbed ? '&embed=true' : ''
-              }`}
+              link={`/stakeholder/stakeholders/${id}${nextExtraKeyword ? `?keyword=${nextExtraKeyword}${isEmbed ? '&embed=true' : ''}` : isEmbed ? '?embed=true' : ''}`}
             />
           </Box>
         )}
@@ -597,9 +595,7 @@ export default function Capture({
             cardImageSrc={grower?.image_url || imagePlaceholder}
             rotation={grower?.image_rotation}
             // TODO: this wont work until growers page is completed
-            link={`/grower-accounts/${grower.id}?keyword=${nextExtraKeyword}${
-              isEmbed ? '&embed=true' : ''
-            }`}
+            link={`/grower-accounts/${grower.id}${nextExtraKeyword ? `?keyword=${nextExtraKeyword}${isEmbed ? '&embed=true' : ''}` : isEmbed ? '?embed=true' : ''}`}
           />
         </Box>
         <Typography


### PR DESCRIPTION
## Summary

Fixes #1813

When navigating from a tree/capture page to an organization, planter, stakeholder, or grower page, entity links included `?keyword=undefined` in the URL. This happened because `nextExtraKeyword` (sourced from `router.query.keyword` in `_app.js`) is `undefined` when no search keyword is active, and JavaScript template literals coerce `undefined` to the string `"undefined"`.

## Root Cause

```js
// _app.js line 88
const nextExtraKeyword = router.query.keyword; // undefined when no keyword param

// [treeid].js — interpolated directly into template literal
link={`/organizations/${id}?keyword=${nextExtraKeyword}...`}
// produces: /organizations/2836?keyword=undefined
```

## Fix

Conditionally include the `keyword` query parameter only when `nextExtraKeyword` has a real value. Also correctly handles the `embed` parameter when keyword is absent.

**4 instances fixed across 2 files:**
- `src/pages/trees/[treeid].js` — organization link, planter link
- `src/pages/v2/captures/[captureid].js` — stakeholder link, grower link

## Test Plan

- [ ] Open a tree page (e.g. `/trees/8253212`) — click organization link → URL should NOT contain `?keyword=undefined`
- [ ] Open a tree page with keyword in URL (e.g. `?keyword=test`) — click organization link → URL should contain `?keyword=test`
- [ ] Same checks for planter links on tree pages
- [ ] Same checks for stakeholder/grower links on capture pages (v2)

<!-- DCCE:AI-BEGIN
{
  "dcceVersion": "0.1",
  "id": "f018e5da-e4cf-47f9-b1d8-4c0209a00791",
  "contentType": "pr_description",
  "ai": {
    "issue": "#1813",
    "type": "bugfix",
    "root_cause": "JS template literal coercion of undefined to string 'undefined' when router.query.keyword is not set",
    "files_changed": ["src/pages/trees/[treeid].js", "src/pages/v2/captures/[captureid].js"],
    "instances_fixed": 4,
    "links_affected": ["organization", "planter", "stakeholder", "grower"],
    "fix_approach": "conditional keyword param inclusion via ternary in template literals",
    "breaking_changes": false,
    "m7_cycle_id": "cycle_fix-greenstandtreetr_497377"
  },
  "provenance": {
    "actor": "ai",
    "tool": "M7 MCP",
    "model": "claude-4.6-opus",
    "generatedAt": "2026-02-10T02:31:58.570Z"
  }
}
DCCE:AI-END -->

Made with [M7 Cursor](https://cursor.com)