### PR TITLE
fix: expand .gitignore to cover all .env file variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # misc
 **/.DS_Store
+.env*
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
# Description
## What
Adds `.env*` wildcard to `.gitignore` to cover all environment variable file variants.

## Why
The current `.gitignore` was generated from Create React App's default template and only excludes `.local` suffixed variants:

- .env.local
- .env.development.local
- .env.test.local
- .env.production.local

A bare `.env` file, or any variant without the `.local` suffix (e.g. `.env.development`, `.env.production`), would not be caught and could be committed unintentionally.

Other Greenstand repos such as `treetracker-query-api` already use `.env*` for this reason. This change brings `treetracker-web-map-client` in line with that pattern.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Change
Added `.env*` to `.gitignore`.

The existing `.local` entries are now redundant but are kept to avoid unnecessary diff noise and maintain compatibility with any tooling that references them explicitly.


