### PR TITLE
fix: disable ISR memory cache; set prod resource limits

### DIFF
--- a/deployment/overlays/prod/deployment.yaml
+++ b/deployment/overlays/prod/deployment.yaml
@@ -26,3 +26,12 @@ spec:
               value: 'false'
             - name: NEXT_PUBLIC_GA_ID
               value: G-6QS615H24Z
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=1344"
+          resources:
+            requests:
+              memory: "1300Mi"
+              cpu: "50m"
+            limits:
+              memory: "1792Mi"
+              cpu: "200m"

--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,9 @@ const withImages = require('next-images');
 
 module.exports = {
   ...withImages(),
+  experimental: {
+    isrMemoryCacheSize: 0,
+  },
   images: {
     domains: [
       'treetracker-production-images.s3.eu-central-1.amazonaws.com',


### PR DESCRIPTION
- Set isrMemoryCacheSize: 0 to eliminate LRU bug exposure and reduce memory overhead
- memory request: 1300Mi, limit: 1792Mi (based on observed ~1266Mi steady-state)
- NODE_OPTIONS --max-old-space-size=1344 (75% of limit)
- cpu request: 50m, limit: 200m

# Description
Fixes recurring OOMKills on the production web-map-client pod caused by unbounded 
Next.js ISR in-memory cache growth and absence of Kubernetes resource limits.

Observed steady-state memory usage: ~1,266Mi.
Fix for: https://github.com/Greenstand/treetracker-infrastructure/issues/306
Related to:  https://github.com/Greenstand/treetracker-infrastructure/issues/300

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
N/A — infrastructure/config change, no UI impact.

# How Has This Been Tested?
- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

> Note: This change affects runtime memory configuration and Kubernetes resource 
> limits only. No application logic was modified. Verification is via pod stability 
> monitoring post-deployment.

# Notes
- `deployment-main/` intentionally not patched — last commit July 2023, considered dormant

# Deployment notes
Resource limit changes will trigger an automatic rolling restart on apply. 
No manual intervention required. Monitor pod memory on first deployment to 
confirm steady-state stays within the 1792Mi limit.


# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules