### PR TITLE
fix: increase ISR revalidation interval from 30s to 300s on content p…

### DIFF
--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -505,7 +505,7 @@ const getStaticProps = wrapper(async ({ params }) => {
   const props = await serverSideData(params);
   return {
     props,
-    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 30,
+    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 300,
   };
 });
 

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -537,7 +537,7 @@ const getStaticProps = wrapper(async ({ params }) => {
   const props = await serverSideData(params);
   return {
     props,
-    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 30,
+    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 300,
   };
 });
 

--- a/src/pages/top.js
+++ b/src/pages/top.js
@@ -292,7 +292,7 @@ const getStaticProps = utils.wrapper(async ({ params }) => {
   const props = await serverSideData(params);
   return {
     props,
-    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 30,
+    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 300,
   };
 });
 

--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -752,7 +752,7 @@ const getStaticProps = utils.wrapper(async ({ params }) => {
   const props = await serverSideData(params);
   return {
     props,
-    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 30,
+    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 300,
   };
 });
 

--- a/src/pages/v2/captures/[captureid].js
+++ b/src/pages/v2/captures/[captureid].js
@@ -754,7 +754,7 @@ const getStaticProps = utils.wrapper(async ({ params }) => {
   const props = await serverSideData(params);
   return {
     props,
-    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 30,
+    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 300,
   };
 });
 

--- a/src/pages/wallets/[walletid].js
+++ b/src/pages/wallets/[walletid].js
@@ -422,7 +422,7 @@ const getStaticProps = wrapper(async ({ params }) => {
   const props = await serverSideData(params);
   return {
     props,
-    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 30,
+    revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 300,
   };
 });
 


### PR DESCRIPTION
# Description
Increases the default ISR revalidation interval from 30s to 300s across all 
active content pages (planters, organizations, trees, captures, wallets, top).

`NEXT_CACHE_REVALIDATION_OVERRIDE` env var is still respected and takes 
precedence if set. `src/models/utils.js` is intentionally left at 30s — that 
path handles error recovery retries, where faster revalidation is appropriate.

These are low-churn content pages. A 30s revalidation cycle generates 
continuous background regeneration work with no meaningful freshness benefit 
to users. This follows the previous PR disabling the in-memory ISR cache in 
favour of disk cache for Kubernetes compatibility. With that change in place, 
each revalidation triggers a disk write cycle — reducing frequency by 10x 
reduces that churn accordingly.

Pages will show data up to 5 minutes stale after an update vs 30 seconds 
previously. For these content types this is acceptable.

As follow up to PR #1824 
Related fix for issue https://github.com/Greenstand/treetracker-infrastructure/issues/306
Related fix for issue https://github.com/Greenstand/treetracker-infrastructure/issues/300

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
N/A — no UI changes.

# How Has This Been Tested?
- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works - see PR #1826 
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules