### PR TITLE
Fix/pin kustomize version

### DIFF
--- a/.github/workflows/deploy-main-channel-to-dev.yaml
+++ b/.github/workflows/deploy-main-channel-to-dev.yaml
@@ -83,7 +83,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install kustomize
-        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        # Pin the version so the installer fetches a specific release tag
+        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.4.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run kustomize
         run: (cd deployment/base && ../../kustomize edit set image greenstand/treetracker-web-map-client=greenstand/${{ github.event.repository.name }}-dev:${{ needs.release.outputs.bumped_version }} )
       - name: Install doctl for kubernetes
@@ -95,7 +98,7 @@ jobs:
       #- name: Delete completed migration jobs prior to deployment
       #  run: kubectl -n ${{ secrets.K8S_NAMESPACE }} delete job --ignore-not-found=true  database-migration-job
       - name: Update kubernetes resources
-        run: kustomize build deployment/overlays/development | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -
+        run: ./kustomize build deployment/overlays/development | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -
       #- name: Attempt to wait for migration job to complete
       #  run: kubectl wait -n ${{ secrets.K8S_NAMESPACE }} --for=condition=complete --timeout=45s job/database-migration-job
 #  deploy:

--- a/.github/workflows/deploy-main-channel-to-prod.yaml
+++ b/.github/workflows/deploy-main-channel-to-prod.yaml
@@ -37,7 +37,12 @@ jobs:
           export BUMPED_VERSION="${{ github.event.inputs.git-tag }}"
           echo "bumped_version=${BUMPED_VERSION}" >> $GITHUB_OUTPUT
       - name: Install kustomize
-        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        # Pin the version so the installer fetches a specific release tag instead of
+        # querying the GitHub API for "latest" (unauthenticated -> rate-limited on
+        # shared runners, which intermittently broke the download). Token raises the API limit.
+        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.4.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run kustomize
         run: (cd deployment/base && ../../kustomize edit set image greenstand/${{ github.event.repository.name }}:${{ github.event.inputs.git-tag }} )
       - name: Install doctl for kubernetes
@@ -49,7 +54,7 @@ jobs:
       #- name: Delete completed migration jobs prior to deployment
       #  run: kubectl -n ${{ secrets.K8S_NAMESPACE }} delete job --ignore-not-found=true  database-migration-job
       - name: Update kubernetes resources
-        run: kustomize build deployment/overlays/prod | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -
+        run: ./kustomize build deployment/overlays/prod | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -
       #- name: Attempt to wait for migration job to complete
       #  run: kubectl wait -n ${{ secrets.K8S_NAMESPACE }} --for=condition=complete --timeout=45s job/database-migration-job
 #  deploy:

--- a/.github/workflows/deploy-main-channel-to-prod.yaml
+++ b/.github/workflows/deploy-main-channel-to-prod.yaml
@@ -37,9 +37,7 @@ jobs:
           export BUMPED_VERSION="${{ github.event.inputs.git-tag }}"
           echo "bumped_version=${BUMPED_VERSION}" >> $GITHUB_OUTPUT
       - name: Install kustomize
-        # Pin the version so the installer fetches a specific release tag instead of
-        # querying the GitHub API for "latest" (unauthenticated -> rate-limited on
-        # shared runners, which intermittently broke the download). Token raises the API limit.
+        # Pin the version so the installer fetches a specific release tag
         run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.4.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-main-channel-to-test.yaml
+++ b/.github/workflows/deploy-main-channel-to-test.yaml
@@ -54,7 +54,10 @@ jobs:
           file: ./Dockerfile-test
           tags: greenstand/${{ github.event.repository.name }}-test:${{ steps.package-version.outputs.current-version }}
       - name: Install kustomize
-        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        # Pin the version so the installer fetches a specific release tag
+        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.4.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run kustomize
         run: (cd deployment/base && ../../kustomize edit set image greenstand/treetracker-web-map-client=greenstand/${{ github.event.repository.name }}-test:${{ steps.export_bumped_version.outputs.bumped_version }} )
       - name: Install doctl for kubernetes
@@ -66,7 +69,7 @@ jobs:
       #- name: Delete completed migration jobs prior to deployment
       #  run: kubectl -n ${{ secrets.K8S_NAMESPACE }} delete job --ignore-not-found=true  database-migration-job
       - name: Update kubernetes resources
-        run: kustomize build deployment/overlays/test | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -
+        run: ./kustomize build deployment/overlays/test | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -
       #- name: Attempt to wait for migration job to complete
       #  run: kubectl wait -n ${{ secrets.K8S_NAMESPACE }} --for=condition=complete --timeout=45s job/database-migration-job
 #  deploy:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,7 +43,10 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@master
       - name: Install kustomize
-        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        # Pin the version so the installer fetches a specific release tag
+        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.4.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Calculate the channel 
         id: channel
         run: |
@@ -107,4 +110,4 @@ jobs:
       - name: Print overlay folder
         run: echo ${{ steps.overlay_folder.outputs.OVERLAY_FOLDER }}
       - name: Update kubernetes resources
-        run: kustomize build ${{ steps.channel.outputs.CHANNEL == 'master' && 'deployment' || format('deployment-{0}',steps.channel.outputs.CHANNEL) }}/overlays/${{ steps.overlay_folder.outputs.OVERLAY_FOLDER}} | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -
+        run: ./kustomize build ${{ steps.channel.outputs.CHANNEL == 'master' && 'deployment' || format('deployment-{0}',steps.channel.outputs.CHANNEL) }}/overlays/${{ steps.overlay_folder.outputs.OVERLAY_FOLDER}} | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -

--- a/.github/workflows/dev-build-release.yaml
+++ b/.github/workflows/dev-build-release.yaml
@@ -113,7 +113,10 @@ jobs:
       run: |
        echo "bumped_version=${{ needs.build-and-push-docker.outputs.bumped_version }}" >> $GITHUB_OUTPUT
     - name: Install kustomize
-      run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+      # Pin the version so the installer fetches a specific release tag
+      run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.4.3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     #- name: Load channel
     #  run: echo CHANNEL=$(echo `node -e ' process.env.GITHUB_REF_NAME === "master" ? console.log("master") :console.log(require("./.releaserc.json").branches.reduce((a,c) => a || c.name === process.env.GITHUB_REF_NAME  && "-" + c.channel, false))'`) >> $GITHUB_OUTPUT
     #  id: channel
@@ -128,5 +131,5 @@ jobs:
     - name: Save DigitalOcean kubeconfig
       run: doctl kubernetes cluster kubeconfig save ${{ secrets.DEV_CLUSTER_NAME }}
     - name: Update kubernetes resources
-      run: kustomize build deployment/overlays/development | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -
+      run: ./kustomize build deployment/overlays/development | kubectl apply -n ${{ secrets.K8S_NAMESPACE }} --wait -f -
 


### PR DESCRIPTION
# Description

The deploy workflows install `kustomize` via the upstream `install_kustomize.sh` script with **no version specified**. In that mode the script calls the GitHub releases API (unauthenticated) to resolve the "latest" version. On shared GitHub-hosted runners that anonymous call frequently gets rate-limited, so the version comes back empty and the script tries to untar a placeholder file (`kustomize_v*_linux_amd64.tar.gz`), failing with `Cannot open: No such file or directory` and killing the deploy before it starts.

This pins kustomize to a specific version across all deploy workflows, which makes the install deterministic and removes the unreliable "latest" lookup.
Changes (applied to `deploy.yaml`, `deploy-main-channel-to-dev/test/prod.yaml`,
`dev-build-release.yaml`):
- **Pin the version**: `... install_kustomize.sh | bash -s -- 5.4.3` so the installer fetches a specific release tag instead of querying for "latest".
- **Authenticate the API call**: pass the built-in `GITHUB_TOKEN` to the install step, raising the rate limit from 60 to 5,000 req/hr.
- **Use the pinned binary on apply**: `kustomize build` → `./kustomize build`, so the deploy uses the pinned 5.4.3 end-to-end instead of the runner's pre-installed kustomize.

Fixes # (deploy action failure at the "Install kustomize" step)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A — CI/deployment workflow change, no UI impact.

# How Has This Been Tested?

Not applicable (no application code changed). Validated by:
- Confirmed the pinned `5.4.3` release tag and the `linux_amd64` asset resolve (HTTP 200).
- Validated all workflow YAML files parse correctly.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
