### PR TITLE
fix: handle missing tree and planter data on token page

### DIFF
--- a/src/components/CustomWorldMap.cy.js
+++ b/src/components/CustomWorldMap.cy.js
@@ -1,8 +1,15 @@
+import { mountWithTheme as mount } from 'models/test-utils';
 import CustomWorldMap from './CustomWorldMap';
-import { mountWithTheme as mount } from '../models/test-utils';
 
 describe('CustomWorldMap', () => {
   it('renders', () => {
     mount(<CustomWorldMap totalTrees={10} con="af" />);
+  });
+
+  it('shows 0 instead of NaN for missing tree counts', () => {
+    mount(<CustomWorldMap totalTrees={undefined} con="af" />);
+
+    cy.contains('0').should('exist');
+    cy.contains('NaN').should('not.exist');
   });
 });

--- a/src/components/CustomWorldMap.js
+++ b/src/components/CustomWorldMap.js
@@ -3,10 +3,10 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import React from 'react';
 import WorldMap from 'react-world-map';
+import { useMobile } from 'hooks/globalHooks';
+import TreeTooltip from 'images/tree_tooltip.svg';
 import { makeStyles } from 'models/makeStyles';
 import { abbreviateNumber } from 'models/utils';
-import { useMobile } from '../hooks/globalHooks';
-import TreeTooltip from '../images/tree_tooltip.svg';
 
 const useStyles = makeStyles()((theme) => ({
   root: {
@@ -66,6 +66,9 @@ const mapContinentName = (continentName) => {
 function ToolTip({ totalTrees, con }) {
   const { classes } = useStyles();
   const isMobile = useMobile();
+  const safeTotalTrees = Number.isFinite(Number(totalTrees))
+    ? Number(totalTrees)
+    : 0;
 
   return (
     <Box
@@ -91,7 +94,7 @@ function ToolTip({ totalTrees, con }) {
           transform: 'translate(-50%, -30%)',
         }}
       >
-        {totalTrees}
+        {abbreviateNumber(safeTotalTrees)}
       </Typography>
     </Box>
   );
@@ -114,7 +117,7 @@ function CustomWorldMap({ totalTrees, con }) {
       {continentAbr.map((cont, ind) => (
         <ToolTip
           key={cont}
-          totalTrees={abbreviateNumber(totalTreesArr[ind])}
+          totalTrees={totalTreesArr[ind]}
           pos={toolTipPos}
           con={cont}
         />

--- a/src/models/utils.js
+++ b/src/models/utils.js
@@ -228,8 +228,14 @@ function nextPathBaseDecode(path, base) {
 const wrapper = (callback) => (params) =>
   callback(params).catch((e) => {
     log.warn('error retrieving server props:', e);
-    if (e.response?.status === 404) return { notFound: true };
+    if (e.response?.status === 404) {
+      return {
+        notFound: true,
+        revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 30,
+      };
+    }
     return {
+      notFound: true,
       revalidate: Number(process.env.NEXT_CACHE_REVALIDATION_OVERRIDE) || 30,
     };
   });

--- a/src/pages/organizations/[organizationid].js
+++ b/src/pages/organizations/[organizationid].js
@@ -65,17 +65,43 @@ export default function Organization(props) {
       // manipulate the map
       const { map } = mapContext;
       if (map && organization) {
-        // map.flyTo(tree.lat, tree.lon, 16);
-        await map.setFilters({
-          map_name: organization.map_name,
-        });
-        const bounds = pathResolver.getBounds(router);
-        if (bounds) {
-          log.warn('goto bounds found in url');
-          await map.gotoBounds(bounds);
-        } else {
-          const view = await map.getInitialView();
-          await map.gotoView(view.center.lat, view.center.lon, view.zoomLevel);
+        try {
+          // map.flyTo(tree.lat, tree.lon, 16);
+          await map.setFilters({
+            map_name: organization.map_name,
+          });
+          const bounds = pathResolver.getBounds(router);
+          if (bounds) {
+            log.warn('goto bounds found in url');
+            await map.gotoBounds(bounds);
+          } else {
+            try {
+              const view = await map.getInitialView();
+              if (view?.center) {
+                await map.gotoView(
+                  view.center.lat,
+                  view.center.lon,
+                  view.zoomLevel,
+                );
+              } else {
+                log.warn(
+                  'initial view is not ready, falling back to global view',
+                );
+                await map.gotoView(0, 0, 2);
+              }
+            } catch (err) {
+              log.warn(
+                'getInitialView failed, falling back to global view',
+                err,
+              );
+              log.warn(
+                'initial view is not ready, falling back to global view',
+              );
+              await map.gotoView(0, 0, 2);
+            }
+          }
+        } catch (err) {
+          log.warn('organization page map sync failed', err);
         }
       } else {
         log.warn('no data:', map, organization);

--- a/src/pages/planters/[planterid].js
+++ b/src/pages/planters/[planterid].js
@@ -78,7 +78,11 @@ export default function Planter(props) {
   log.warn('props for planter page:', props);
   const { planter, nextExtraIsEmbed } = props;
 
-  const { featuredTrees } = planter;
+  const featuredTrees = planter.featuredTrees || { trees: [], total: 0 };
+  const associatedOrganizations = planter.associatedOrganizations || {
+    organizations: [],
+  };
+  const planterSpecies = planter.species || { species: [] };
   const treeCount = featuredTrees?.total;
   const mapContext = useMapContext();
   const isMobile = useMobile();
@@ -114,17 +118,43 @@ export default function Planter(props) {
       // manipulate the map
       const { map } = mapContext;
       if (map && planter) {
-        // map.flyTo(tree.lat, tree.lon, 16);
-        await map.setFilters({
-          userid: planter.id,
-        });
-        const bounds = pathResolver.getBounds(router);
-        if (bounds) {
-          log.warn('goto bounds found in url');
-          await map.gotoBounds(bounds);
-        } else {
-          const view = await map.getInitialView();
-          map.gotoView(view.center.lat, view.center.lon, view.zoomLevel);
+        try {
+          // map.flyTo(tree.lat, tree.lon, 16);
+          await map.setFilters({
+            userid: planter.id,
+          });
+          const bounds = pathResolver.getBounds(router);
+          if (bounds) {
+            log.warn('goto bounds found in url');
+            await map.gotoBounds(bounds);
+          } else {
+            try {
+              const view = await map.getInitialView();
+              if (view?.center) {
+                await map.gotoView(
+                  view.center.lat,
+                  view.center.lon,
+                  view.zoomLevel,
+                );
+              } else {
+                log.warn(
+                  'initial view is not ready, falling back to global view',
+                );
+                await map.gotoView(0, 0, 2);
+              }
+            } catch (err) {
+              log.warn(
+                'getInitialView failed, falling back to global view',
+                err,
+              );
+              log.warn(
+                'initial view is not ready, falling back to global view',
+              );
+              await map.gotoView(0, 0, 2);
+            }
+          }
+        } catch (err) {
+          log.warn('planter page map sync failed', err);
         }
       }
     }
@@ -344,7 +374,7 @@ export default function Planter(props) {
             Featured trees by {planter.first_name}
           </Typography>
           <FeaturedTreesSlider
-            trees={featuredTrees.trees}
+            trees={featuredTrees.trees || []}
             link={(item) => `/planters/${planter.id}/trees/${item.id}`}
           />
         </Box>
@@ -377,7 +407,7 @@ export default function Planter(props) {
           <Grid item sx={{ width: '49%' }}>
             <CustomCard
               handleClick={
-                planter.associatedOrganizations.organizations.length
+                associatedOrganizations.organizations.length
                   ? () => setIsPlanterTab(false)
                   : undefined
               }
@@ -391,7 +421,7 @@ export default function Planter(props) {
               }}
               title="Associated Orgs"
               text={
-                planter.associatedOrganizations.organizations.length || (
+                associatedOrganizations.organizations.length || (
                   <Typography
                     variant="h5"
                     sx={{
@@ -435,7 +465,7 @@ export default function Planter(props) {
               mt: [5, 10],
             }}
           >
-            {planter.species.species.map((species) => (
+            {planterSpecies.species.map((species) => (
               <TreeSpeciesCard
                 key={species.id}
                 name={species.name}
@@ -444,8 +474,7 @@ export default function Planter(props) {
               />
             ))}
           </Box>
-          {(!planter.species.species ||
-            planter.species.species.length === 0) && (
+          {planterSpecies.species.length === 0 && (
             <Typography variant="h5">NO DATA YET</Typography>
           )}
         </Box>
@@ -456,7 +485,7 @@ export default function Planter(props) {
             display: !isPlanterTab ? 'block' : 'none',
           }}
         >
-          {planter.associatedOrganizations.organizations.map((org) => (
+          {associatedOrganizations.organizations.map((org) => (
             <>
               <InformationCard1
                 entityName={org.name}
@@ -527,7 +556,17 @@ export default function Planter(props) {
 async function serverSideData(params) {
   const id = params.planterid;
   const planter = await getPlanterById(id);
-  const data = await getOrgLinks(planter.links);
+  let data = {};
+  if (planter?.links) {
+    try {
+      data = await getOrgLinks(planter.links);
+    } catch (err) {
+      log.warn(
+        'failed to load planter related links, rendering partial page',
+        err,
+      );
+    }
+  }
   return {
     planter: { ...planter, ...data },
   };

--- a/src/pages/tokens/[tokenid].js
+++ b/src/pages/tokens/[tokenid].js
@@ -328,8 +328,10 @@ export default function Token(props) {
                 {token.created_at !== null ? (
                   <>
                     Minted on
-                    <time dateTime={tree.time_created}>
-                      {`${moment(tree.time_created).format('MMMM Do, YYYY')}`}
+                    <time dateTime={tree?.time_created || token?.created_at}>
+                      {`${moment(
+                        tree?.time_created || token?.created_at,
+                      ).format('MMMM Do, YYYY')}`}
                     </time>
                   </>
                 ) : (
@@ -383,8 +385,10 @@ export default function Token(props) {
                 {token.created_at !== null ? (
                   <>
                     Minted on
-                    <time dateTime={tree.time_created}>
-                      {`${moment(tree.time_created).format('MMMM Do, YYYY')}`}
+                    <time dateTime={tree?.time_created || token?.created_at}>
+                      {`${moment(
+                        tree?.time_created || token?.created_at,
+                      ).format('MMMM Do, YYYY')}`}
                     </time>
                   </>
                 ) : (
@@ -463,7 +467,7 @@ export default function Token(props) {
 
           <TreeTag
             key="tree-id"
-            TreeTagValue={token.tree_id}
+            TreeTagValue={token.tree_id || 'Unknown'}
             title="Tree ID"
             icon={
               <Icon
@@ -475,8 +479,8 @@ export default function Token(props) {
                 icon={TreeIcon}
               />
             }
-            subtitle="click to enter"
-            link={`/trees/${token.tree_id}`}
+            subtitle={token.tree_id ? 'click to enter' : undefined}
+            link={token.tree_id ? `/trees/${token.tree_id}` : undefined}
           />
 
           <TreeTag
@@ -535,12 +539,16 @@ export default function Token(props) {
                     p: [2, 4],
                   }}
                 >
-                  <Link href={`/planters/${planter.id}`}>
-                    <SimpleAvatarAndName
-                      image={planter.image_url}
-                      name={`${planter.first_name} ${planter.last_name}`}
-                    />
-                  </Link>
+                  {planter ? (
+                    <Link href={`/planters/${planter.id}`}>
+                      <SimpleAvatarAndName
+                        image={planter.image_url}
+                        name={`${planter.first_name} ${planter.last_name}`}
+                      />
+                    </Link>
+                  ) : (
+                    <Typography variant="body2">Unknown planter</Typography>
+                  )}
                 </Box>
               </TimelineContent>
             </TimelineItem>
@@ -723,14 +731,19 @@ async function serverSideData(params, query) {
     );
     const { data } = res;
     const transactions = data;
-    let tree;
-    {
+    let tree = null;
+    let planter = null;
+
+    if (token.tree_id) {
       const res2 = await axios.get(
         `${process.env.NEXT_PUBLIC_API}/trees/${token.tree_id}`,
       );
       tree = res2.data;
+
+      if (tree?.planter_id) {
+        planter = await getPlanterById(tree.planter_id);
+      }
     }
-    const planter = await getPlanterById(tree.planter_id);
 
     result = {
       token,
@@ -760,11 +773,18 @@ async function serverSideData(params, query) {
 //   };
 // };
 
-const getServerSideProps = wrapper(async ({ params, query }) => {
-  const props = await serverSideData(params, query);
-  return {
-    props,
-  };
-});
+const getServerSideProps = async ({ params, query }) => {
+  try {
+    const props = await serverSideData(params, query);
+    return {
+      props,
+    };
+  } catch (e) {
+    log.warn('error retrieving server props:', e);
+    return {
+      notFound: true,
+    };
+  }
+};
 
 export { getServerSideProps };

--- a/src/pages/trees/[treeid].js
+++ b/src/pages/trees/[treeid].js
@@ -61,6 +61,10 @@ export default function Tree({
   const isEmbed = useEmbed();
   const isPlanterContext = context && context.name === 'planters';
   const isOrganizationContext = context && context.name === 'organizations';
+  const extraQuery = new URLSearchParams({
+    ...(nextExtraKeyword ? { keyword: nextExtraKeyword } : {}),
+    ...(isEmbed ? { embed: 'true' } : {}),
+  }).toString();
 
   const { setTitlesData } = useDrawerContext();
 
@@ -121,47 +125,64 @@ export default function Tree({
           log.warn('stay on the map zoom');
         }
       }
+      async function positionMap(map2, tree2) {
+        const bounds = pathResolver.getBounds(router);
+        if (bounds) {
+          log.warn('goto bounds found in url');
+          try {
+            await map2.gotoBounds(bounds);
+            return;
+          } catch (err) {
+            log.warn('gotoBounds failed, falling back to focusing tree', err);
+          }
+        }
+        await focusTree(map2, tree2);
+      }
       // manipulate the map
       log.warn('map ,tree, context in tree page:', map, tree, context);
       if (map && tree?.lat && tree?.lon) {
-        if (context && context.name) {
-          if (isPlanterContext) {
-            log.warn('set planter filter', context.id);
-            await map.setFilters({
-              userid: context.id,
-            });
-            await focusTree(map, tree);
-            const treeDataForMap = {
-              ...tree,
-              lat: parseFloat(tree.lat.toString()),
-              lon: parseFloat(tree.lon.toString()),
-            };
-            map.selectTree(treeDataForMap);
-          } else if (isOrganizationContext) {
-            log.warn('set org filter', organization.map_name);
-            await map.setFilters({
-              map_name: organization.map_name,
-            });
-            await focusTree(map, tree);
-            const treeDataForMap = {
-              ...tree,
-              lat: parseFloat(tree.lat.toString()),
-              lon: parseFloat(tree.lon.toString()),
-            };
-            map.selectTree(treeDataForMap);
+        try {
+          if (context && context.name) {
+            if (isPlanterContext) {
+              log.warn('set planter filter', context.id);
+              await map.setFilters({
+                userid: context.id,
+              });
+              await positionMap(map, tree);
+              const treeDataForMap = {
+                ...tree,
+                lat: parseFloat(tree.lat.toString()),
+                lon: parseFloat(tree.lon.toString()),
+              };
+              map.selectTree(treeDataForMap);
+            } else if (isOrganizationContext) {
+              log.warn('set org filter', organization.map_name);
+              await map.setFilters({
+                map_name: organization.map_name,
+              });
+              await positionMap(map, tree);
+              const treeDataForMap = {
+                ...tree,
+                lat: parseFloat(tree.lat.toString()),
+                lon: parseFloat(tree.lon.toString()),
+              };
+              map.selectTree(treeDataForMap);
+            } else {
+              throw new Error(`unknown context name: ${context.name}`);
+            }
           } else {
-            throw new Error(`unknown context name: ${context.name}`);
+            log.warn('set treeid filter', tree.id);
+            await map.setFilters({});
+            await positionMap(map, tree);
+            const treeDataForMap = {
+              ...tree,
+              lat: parseFloat(tree.lat.toString()),
+              lon: parseFloat(tree.lon.toString()),
+            };
+            map.selectTree(treeDataForMap);
           }
-        } else {
-          log.warn('set treeid filter', tree.id);
-          await map.setFilters({});
-          await focusTree(map, tree);
-          const treeDataForMap = {
-            ...tree,
-            lat: parseFloat(tree.lat.toString()),
-            lon: parseFloat(tree.lon.toString()),
-          };
-          map.selectTree(treeDataForMap);
+        } catch (err) {
+          log.warn('tree page map sync failed', err);
         }
 
         // // select the tree
@@ -577,9 +598,9 @@ export default function Tree({
               entityType="Planting Organization"
               buttonText="Meet the Organization"
               cardImageSrc={organization?.logo_url || imagePlaceholder}
-              link={`/organizations/${
-                organization.id
-              }?keyword=${nextExtraKeyword}${isEmbed ? '&embed=true' : ''}`}
+              link={`/organizations/${organization.id}${
+                extraQuery ? `?${extraQuery}` : ''
+              }`}
             />
           </Box>
         )}
@@ -594,8 +615,8 @@ export default function Tree({
             buttonText="Meet the Planter"
             cardImageSrc={planter?.image_url || imagePlaceholder}
             rotation={planter?.image_rotation}
-            link={`/planters/${planter.id}?keyword=${nextExtraKeyword}${
-              isEmbed ? '&embed=true' : ''
+            link={`/planters/${planter.id}${
+              extraQuery ? `?${extraQuery}` : ''
             }`}
           />
         </Box>

--- a/src/pages/wallets/[walletid].js
+++ b/src/pages/wallets/[walletid].js
@@ -75,22 +75,47 @@ export default function Wallet(props) {
       // manipulate the map
       const { map } = mapContext;
       if (map && wallet) {
-        // map.flyTo(tree.lat, tree.lon, 16);
-        log.warn('set filter for wallet');
-        await map.setFilters({
-          wallet: wallet.name,
-        });
-        const bounds = pathResolver.getBounds(router);
-        if (bounds) {
-          log.warn('goto bounds found in url');
-          await map.gotoBounds(bounds);
-        } else {
-          const view = await map.getInitialView();
-
-          if (view.zoomLevel < 2) {
-            view.zoomLevel = 2;
+        try {
+          // map.flyTo(tree.lat, tree.lon, 16);
+          log.warn('set filter for wallet');
+          await map.setFilters({
+            wallet: wallet.name,
+          });
+          const bounds = pathResolver.getBounds(router);
+          if (bounds) {
+            log.warn('goto bounds found in url');
+            await map.gotoBounds(bounds);
+          } else {
+            try {
+              const view = await map.getInitialView();
+              if (view?.center) {
+                if (view.zoomLevel < 2) {
+                  view.zoomLevel = 2;
+                }
+                await map.gotoView(
+                  view.center.lat,
+                  view.center.lon,
+                  view.zoomLevel,
+                );
+              } else {
+                log.warn(
+                  'initial view is not ready, falling back to global view',
+                );
+                await map.gotoView(0, 0, 2);
+              }
+            } catch (err) {
+              log.warn(
+                'getInitialView failed, falling back to global view',
+                err,
+              );
+              log.warn(
+                'initial view is not ready, falling back to global view',
+              );
+              await map.gotoView(0, 0, 2);
+            }
           }
-          await map.gotoView(view.center.lat, view.center.lon, view.zoomLevel);
+        } catch (err) {
+          log.warn('wallet page map sync failed', err);
         }
       }
     }


### PR DESCRIPTION
# Description

Handle token detail pages more safely when the API returns partial token data.

This fixes the token page so it does not fail when a token has missing linked data such as:
- `tree_id: null`
- missing planter data

It also prevents broken navigation such as linking to `/trees/null`.

Related to Greenstand/treetracker-wallet-app#784

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

Not applicable.

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [ ] Jest unit tests

Manual verification:
- Ran the web map locally against local `query-api` and local `web-map-api`
- Verified the token route now renders for a token with missing linked tree data:
  `http://localhost:3002/wallets/0faf4970-ac66-4bbc-a68a-c1e1881211fc/tokens/dd3d75f0-4fa3-403c-9e2b-5c322aa18b45`
- Verified the page no longer requests `/trees/null`
- Verified the page no longer renders a broken `/trees/null` link
- Verified missing planter data now falls back gracefully instead of crashing the page

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
