### PR TITLE
fix: improve token page handling for missing data and enhance error logging

### DIFF
--- a/src/pages/tokens/[tokenid].js
+++ b/src/pages/tokens/[tokenid].js
@@ -328,8 +328,10 @@ export default function Token(props) {
                 {token.created_at !== null ? (
                   <>
                     Minted on
-                    <time dateTime={tree.time_created}>
-                      {`${moment(tree.time_created).format('MMMM Do, YYYY')}`}
+                    <time dateTime={tree?.time_created || token?.created_at}>
+                      {`${moment(
+                        tree?.time_created || token?.created_at,
+                      ).format('MMMM Do, YYYY')}`}
                     </time>
                   </>
                 ) : (
@@ -383,8 +385,10 @@ export default function Token(props) {
                 {token.created_at !== null ? (
                   <>
                     Minted on
-                    <time dateTime={tree.time_created}>
-                      {`${moment(tree.time_created).format('MMMM Do, YYYY')}`}
+                    <time dateTime={tree?.time_created || token?.created_at}>
+                      {`${moment(
+                        tree?.time_created || token?.created_at,
+                      ).format('MMMM Do, YYYY')}`}
                     </time>
                   </>
                 ) : (
@@ -463,7 +467,7 @@ export default function Token(props) {
 
           <TreeTag
             key="tree-id"
-            TreeTagValue={token.tree_id}
+            TreeTagValue={token.tree_id || 'Unknown'}
             title="Tree ID"
             icon={
               <Icon
@@ -475,8 +479,8 @@ export default function Token(props) {
                 icon={TreeIcon}
               />
             }
-            subtitle="click to enter"
-            link={`/trees/${token.tree_id}`}
+            subtitle={token.tree_id ? 'click to enter' : undefined}
+            link={token.tree_id ? `/trees/${token.tree_id}` : undefined}
           />
 
           <TreeTag
@@ -535,12 +539,16 @@ export default function Token(props) {
                     p: [2, 4],
                   }}
                 >
-                  <Link href={`/planters/${planter.id}`}>
-                    <SimpleAvatarAndName
-                      image={planter.image_url}
-                      name={`${planter.first_name} ${planter.last_name}`}
-                    />
-                  </Link>
+                  {planter ? (
+                    <Link href={`/planters/${planter.id}`}>
+                      <SimpleAvatarAndName
+                        image={planter.image_url}
+                        name={`${planter.first_name} ${planter.last_name}`}
+                      />
+                    </Link>
+                  ) : (
+                    <Typography variant="body2">Unknown planter</Typography>
+                  )}
                 </Box>
               </TimelineContent>
             </TimelineItem>
@@ -723,14 +731,19 @@ async function serverSideData(params, query) {
     );
     const { data } = res;
     const transactions = data;
-    let tree;
-    {
+    let tree = null;
+    let planter = null;
+
+    if (token.tree_id) {
       const res2 = await axios.get(
         `${process.env.NEXT_PUBLIC_API}/trees/${token.tree_id}`,
       );
       tree = res2.data;
+
+      if (tree?.planter_id) {
+        planter = await getPlanterById(tree.planter_id);
+      }
     }
-    const planter = await getPlanterById(tree.planter_id);
 
     result = {
       token,
@@ -760,11 +773,18 @@ async function serverSideData(params, query) {
 //   };
 // };
 
-const getServerSideProps = wrapper(async ({ params, query }) => {
-  const props = await serverSideData(params, query);
-  return {
-    props,
-  };
-});
+const getServerSideProps = async ({ params, query }) => {
+  try {
+    const props = await serverSideData(params, query);
+    return {
+      props,
+    };
+  } catch (e) {
+    log.warn('error retrieving server props:', e);
+    return {
+      notFound: true,
+    };
+  }
+};
 
 export { getServerSideProps };


### PR DESCRIPTION
# Description

Handle token detail pages more safely when the API returns partial token data.

This fixes the token page so it does not fail when a token has missing linked data such as:
- `tree_id: null`
- missing planter data

It also prevents broken navigation such as linking to `/trees/null`.

Related to Greenstand/treetracker-wallet-app#784

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

Not applicable.

# How Has This Been Tested?

- [ ] Cypress integration
- [ ] Cypress component tests
- [x] Jest unit tests

Manual verification:
- Ran the web map locally against local `query-api` and local `web-map-api`
- Verified the token route now renders for a token with missing linked tree data:
  `http://localhost:3002/wallets/0faf4970-ac66-4bbc-a68a-c1e1881211fc/tokens/dd3d75f0-4fa3-403c-9e2b-5c322aa18b45`
- Verified the page no longer requests `/trees/null`
- Verified the page no longer renders a broken `/trees/null` link
- Verified missing planter data now falls back gracefully instead of crashing the page

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
